### PR TITLE
One congressional districts tile source

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ ogr2ogr -f GeoJSON -t_srs crs:84 data/congressional_districts.geojson data/tl_20
 node process.js data/congressional_districts.geojson
 
 # create Mapbox vector tiles from data
-tippecanoe -o data/cd-114-2015.mbtiles -f -z 12 -Z 0 -pS -pp -l districts -n "US Congressional Districts" data/map.geojson
+tippecanoe -o data/cd-114-2015.mbtiles -f -z 12 -Z 0 -B 0 -pS -pp -l districts -n "US Congressional Districts" data/map.geojson
 
 # upload map data to Mapbox.com
-node upload.js data/cd-114-2015.mbtiles data/map_labels.geojson
+node upload.js data/cd-114-2015.mbtiles
 
 # modify mapbox-style-template.json to use your Mapbox account and save as data/mapbox-style.json
 sed s/'USER'/"$MAPBOX_USERNAME"/g mapbox-style-template.json > data/mapbox-style.json

--- a/example/index.html
+++ b/example/index.html
@@ -76,7 +76,7 @@ var accessToken = 'pk.eyJ1IjoiYWFyb25kZW5uaXMiLCJhIjoiem5LLURoYyJ9.T3tswGTI5ve8_
 
 //** MODIFY THIS SECTION
 // Specify YOUR uploaded Mapbox Studio style URL
-var styleURL = 'mapbox://styles/aarondennis/cinjppgm9002paem5x0w9ajeb';
+var styleURL = 'mapbox://styles/aarondennis/cioafmhk70047adnmt3gz2kd0';
 var mapId = 'aarondennis.cd-114-2015'; // used by the click handler only
 
 

--- a/mapbox-style-template.json
+++ b/mapbox-style-template.json
@@ -1,483 +1,164 @@
 {
     "version": 8,
-    "name": "congressional-districts-style-v8-copy",
+    "name": "Congressional Districts",
     "metadata": {
+        "mapbox:autocomposite": true,
+        "mapbox:type": "default",
         "mapbox:groups": {
-            "1444858470265.9292": {
-                "name": "Barriers",
-                "collapsed": true
-            },
-            "1444858143444.556": {
-                "name": "Tunnels",
-                "collapsed": true
-            },
-            "1444858181796.6055": {
-                "name": "Hillshades",
-                "collapsed": true
-            },
-            "1444857916000.3777": {
-                "name": "Place labels",
-                "collapsed": true
-            },
-            "1458486127563.5833": {
-                "name": "District Boundaries"
-            },
-            "1444858096986.3894": {
-                "name": "Marine labels",
-                "collapsed": true
-            },
-            "1444858163779.7869": {
-                "name": "Landuses",
-                "collapsed": true
-            },
-            "1444858262202.7446": {
-                "name": "State labels",
-                "collapsed": true
-            },
-            "1444858128913.9963": {
-                "name": "Roads",
-                "collapsed": true
-            },
-            "1444858082697.2502": {
-                "name": "Bridges",
-                "collapsed": true
-            },
-            "1444858269512.7246": {
-                "name": "Admin boundaries",
-                "collapsed": true
-            },
-            "1444858171723.1826": {
-                "name": "Landcovers",
-                "collapsed": false
-            },
-            "1444858346799.9988": {
-                "name": "POIs",
-                "collapsed": true
-            },
-            "1444858398532.1323": {
-                "name": "Country labels",
-                "collapsed": true
-            },
-            "1444858496690.794": {
-                "name": "Road labels",
-                "collapsed": true
-            },
-            "1458418542199.6687": {
-                "name": "Districts",
-                "collapsed": false
-            },
-            "1444858200762.7805": {
-                "name": "Water",
-                "collapsed": false
-            },
-            "1444858216876.1328": {
-                "name": "Buildings",
-                "collapsed": true
-            },
-            "1444858189651.4805": {
+            "1444934828655.3389": {
                 "name": "Aeroways",
                 "collapsed": true
             },
-            "1458461767759.1262": {
-                "name": "District Labels"
+            "1444933322393.2852": {
+                "name": "POI labels  (scalerank 1)",
+                "collapsed": true
+            },
+            "1444862578782.6787": {
+                "name": "Road labels",
+                "collapsed": true
+            },
+            "1444855786460.0557": {
+                "name": "Roads",
+                "collapsed": true
+            },
+            "1444934295202.7542": {
+                "name": "Admin boundaries",
+                "collapsed": true
+            },
+            "1444856151690.9143": {
+                "name": "State labels",
+                "collapsed": true
+            },
+            "1444933721429.3076": {
+                "name": "Road labels",
+                "collapsed": true
+            },
+            "1444933358918.2366": {
+                "name": "POI labels (scalerank 2)",
+                "collapsed": true
+            },
+            "1444933808272.805": {
+                "name": "Water labels",
+                "collapsed": true
+            },
+            "1444933372896.5967": {
+                "name": "POI labels (scalerank 3)",
+                "collapsed": true
+            },
+            "1444855799204.86": {
+                "name": "Bridges",
+                "collapsed": true
+            },
+            "1444856087950.3635": {
+                "name": "Marine labels",
+                "collapsed": true
+            },
+            "1456969573402.7817": {
+                "name": "Hillshading",
+                "collapsed": true
+            },
+            "1444862510685.128": {
+                "name": "City labels",
+                "collapsed": true
+            },
+            "1444855769305.6016": {
+                "name": "Tunnels",
+                "collapsed": true
+            },
+            "1456970288113.8113": {
+                "name": "Landcover",
+                "collapsed": true
+            },
+            "1444856144497.7825": {
+                "name": "Country labels",
+                "collapsed": true
             }
-        },
-        "mapbox:autocomposite": true
+        }
     },
-    "center": [
-        -76.6407433857464,
-        39.26490432392163
-    ],
-    "zoom": 10.973269295232008,
-    "bearing": 0,
-    "pitch": 0,
     "sources": {
         "composite": {
-            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,USER.cd-114-2015,USER.cd-114-2015-labels",
+            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,USER.cd-114-2015",
             "type": "vector"
         }
     },
-    "sprite": "mapbox://sprites/USER/cinjppgm9002paem5x0w9ajeb",
-    "glyphs": "mapbox://fonts/USER/{fontstack}/{range}.pbf",
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
     "layers": [
         {
             "id": "background",
             "type": "background",
             "interactive": true,
+            "layout": {},
             "paint": {
-                "background-color": "hsl(0, 0%, 89%)",
-                "background-opacity": 1
+                "background-color": "hsl(55, 11%, 96%)"
             }
         },
         {
-            "id": "landcover_scrub_grass",
+            "id": "landcover_wood",
             "type": "fill",
             "metadata": {
-                "mapbox:group": "1444858171723.1826"
+                "mapbox:group": "1456970288113.8113"
             },
             "source": "composite",
             "source-layer": "landcover",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "scrub",
-                "grass"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsla(0, 0%, 95%, 0.26)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.5
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "landcover_crop_wood",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858171723.1826"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "crop",
-                "wood"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsla(0, 0%, 95%, 0.26)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            0.25
-                        ],
-                        [
-                            14,
-                            0.85
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "landcover_snow",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858171723.1826"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "snow"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsla(0, 0%, 95%, 0.26)",
-                "fill-opacity": 0.75
-            }
-        },
-        {
-            "id": "greenery",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "cemetery",
-                "grass"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 92%)",
-                "fill-opacity": 0.65
-            }
-        },
-        {
-            "id": "national_park",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse_overlay",
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "national_park"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 92%)",
-                "fill-opacity": 0.8
-            }
-        },
-        {
-            "id": "school",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "maxzoom": 20,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "school"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 93%)",
-                "fill-outline-color": "hsl(271, 1%, 67%)",
-                "fill-opacity": 1
-            }
-        },
-        {
-            "id": "hospital",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "maxzoom": 20,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "hospital"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 97%)",
-                "fill-outline-color": "hsl(358, 1%, 72%)",
-                "fill-opacity": 1
-            }
-        },
-        {
-            "id": "airport",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "industrial"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "rgba(213,217,213,1)",
-                "fill-opacity": 0.25
-            }
-        },
-        {
-            "id": "sand",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "sand"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 95%)",
-                "fill-opacity": 1
-            }
-        },
-        {
-            "id": "wood",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
+            "maxzoom": 14,
             "interactive": true,
             "filter": [
                 "==",
                 "class",
                 "wood"
             ],
-            "layout": {
-                "visibility": "visible"
-            },
+            "layout": {},
             "paint": {
-                "fill-color": "hsl(0, 0%, 67%)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            6,
-                            0.1
-                        ]
-                    ]
-                }
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
             }
         },
         {
-            "id": "park",
+            "id": "landcover_scrub",
             "type": "fill",
             "metadata": {
-                "mapbox:group": "1444858163779.7869"
+                "mapbox:group": "1456970288113.8113"
             },
             "source": "composite",
-            "source-layer": "landuse",
+            "source-layer": "landcover",
+            "maxzoom": 14,
             "interactive": true,
             "filter": [
-                "in",
+                "==",
                 "class",
-                "park",
-                "national_park"
+                "scrub"
             ],
-            "layout": {
-                "visibility": "visible"
-            },
+            "layout": {},
             "paint": {
-                "fill-color": "hsl(0, 6%, 93%)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            8,
-                            1
-                        ]
-                    ]
-                },
-                "fill-outline-color": "hsl(0, 0%, 80%)"
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
             }
         },
         {
-            "id": "pitch",
+            "id": "landcover_grass",
             "type": "fill",
             "metadata": {
-                "mapbox:group": "1444858163779.7869"
+                "mapbox:group": "1456970288113.8113"
             },
             "source": "composite",
-            "source-layer": "landuse",
+            "source-layer": "landcover",
+            "maxzoom": 14,
             "interactive": true,
             "filter": [
-                "any",
-                [
-                    "in",
-                    "class",
-                    "pitch",
-                    "gras"
-                ],
-                [
-                    "==",
-                    "type",
-                    "golf_course"
-                ]
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "hsl(0, 0%, 87%)",
-                "fill-opacity": 1,
-                "fill-outline-color": "hsl(0, 0%, 80%)"
-            }
-        },
-        {
-            "id": "grass_noise",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858163779.7869"
-            },
-            "source": "composite",
-            "source-layer": "landuse",
-            "interactive": true,
-            "filter": [
-                "in",
+                "==",
                 "class",
-                "cemetery",
-                "pitch",
-                "wood",
-                "park"
+                "grass"
             ],
-            "layout": {
-                "visibility": "visible"
-            },
+            "layout": {},
             "paint": {
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0
-                        ],
-                        [
-                            18,
-                            0.5
-                        ]
-                    ]
-                },
-                "fill-pattern": "grass-noise"
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
             }
         },
-        {
+	 {
             "id": "districts_5",
             "type": "fill",
             "metadata": {
@@ -588,79 +269,6371 @@
             }
         },
         {
-            "id": "water_edge",
-            "type": "line",
+            "id": "landcover_crop",
+            "type": "fill",
             "metadata": {
-                "mapbox:group": "1444858200762.7805"
+                "mapbox:group": "1456970288113.8113"
             },
             "source": "composite",
-            "source-layer": "water",
-            "minzoom": 2,
+            "source-layer": "landcover",
+            "maxzoom": 14,
             "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "crop"
+            ],
+            "layout": {},
             "paint": {
-                "line-color": "rgba(42,99,119,1.000)",
-                "line-opacity": 1,
-                "line-width": {
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "national_park",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse_overlay",
+            "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "national_park"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)",
+                "fill-opacity": {
                     "base": 1,
                     "stops": [
                         [
-                            9,
-                            0.5
-                        ],
-                        [
-                            20,
-                            4
-                        ]
-                    ]
-                },
-                "line-blur": 1
-            }
-        },
-        {
-            "id": "water",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858200762.7805"
-            },
-            "source": "composite",
-            "source-layer": "water",
-            "interactive": true,
-            "paint": {
-                "fill-color": "hsl(192, 100%, 95%)",
-                "fill-outline-color": "#cadcea",
-                "fill-opacity": 0.7
-            }
-        },
-        {
-            "id": "waterway",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858200762.7805"
-            },
-            "source": "composite",
-            "source-layer": "waterway",
-            "interactive": true,
-            "layout": {
-                "line-cap": "round"
-            },
-            "paint": {
-                "line-color": "hsl(180, 27%, 84%)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            6,
+                            5,
                             0
                         ],
                         [
-                            20,
-                            40
+                            6,
+                            0.5
                         ]
                     ]
                 }
             }
         },
         {
+            "id": "parks",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "park"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            6,
+                            0.75
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "pitch",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "pitch"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)"
+            }
+        },
+        {
+            "id": "industrial",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "industrial"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)"
+            }
+        },
+        {
+            "id": "sand",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "interactive": true,
+            "filter": [
+                "==",
+                "class",
+                "sand"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)"
+            }
+        },
+        {
+            "id": "hillshade_highlight_bright",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                94
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "#fff",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.08
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_highlight_med",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                90
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "#fff",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.08
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_faint",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                89
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.033
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_med",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                78
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.033
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_dark",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                67
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.06
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_extreme",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1456969573402.7817"
+            },
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "level",
+                56
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {
+                    "stops": [
+                        [
+                            14,
+                            0.06
+                        ],
+                        [
+                            16,
+                            0
+                        ]
+                    ]
+                },
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "waterway-river-canal",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "waterway",
+            "minzoom": 8,
+            "interactive": true,
+            "filter": [
+                "any",
+                [
+                    "==",
+                    "class",
+                    "canal"
+                ],
+                [
+                    "==",
+                    "class",
+                    "river"
+                ]
+            ],
+            "layout": {
+                "line-cap": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            "butt"
+                        ],
+                        [
+                            11,
+                            "round"
+                        ]
+                    ]
+                },
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#cbd3d4",
+                "line-width": {
+                    "base": 1.3,
+                    "stops": [
+                        [
+                            8.5,
+                            0.1
+                        ],
+                        [
+                            20,
+                            8
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            8,
+                            0
+                        ],
+                        [
+                            8.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "water shadow",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "water",
+            "interactive": true,
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(185, 7%, 73%)",
+                "fill-translate": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                0,
+                                0
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                -1,
+                                -1
+                            ]
+                        ]
+                    ]
+                },
+                "fill-translate-anchor": "viewport",
+                "fill-opacity": 1
+            }
+        },
+        {
+            "id": "water",
+            "ref": "water shadow",
+            "interactive": true,
+            "paint": {
+                "fill-color": "hsl(185, 9%, 81%)"
+            }
+        },
+        {
+            "id": "barrier_line-land-polygon",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "barrier_line",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "Polygon"
+                ],
+                [
+                    "==",
+                    "class",
+                    "land"
+                ]
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "#f0f5f3"
+            }
+        },
+        {
+            "id": "barrier_line-land-line",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "barrier_line",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "==",
+                    "class",
+                    "land"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.99,
+                    "stops": [
+                        [
+                            14,
+                            0.75
+                        ],
+                        [
+                            20,
+                            40
+                        ]
+                    ]
+                },
+                "line-color": "#f0f5f3"
+            }
+        },
+        {
+            "id": "aeroway-polygon",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1444934828655.3389"
+            },
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "Polygon"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "apron"
+                ]
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 97%)",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            11,
+                            0
+                        ],
+                        [
+                            11.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "aeroway-runway",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934828655.3389"
+            },
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 9,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "==",
+                    "type",
+                    "runway"
+                ]
+            ],
+            "layout": {},
+            "paint": {
+                "line-color": "hsl(0, 0%, 95%)",
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            9,
+                            1
+                        ],
+                        [
+                            18,
+                            80
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "aeroway-taxiway",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934828655.3389"
+            },
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 9,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "==",
+                    "type",
+                    "taxiway"
+                ]
+            ],
+            "layout": {},
+            "paint": {
+                "line-color": "hsl(0, 0%, 95%)",
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            10,
+                            0.5
+                        ],
+                        [
+                            18,
+                            20
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "building",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "building",
+            "minzoom": 15,
+            "interactive": true,
+            "filter": [
+                "==",
+                "underground",
+                "false"
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(55, 5%, 91%)",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            15.5,
+                            0
+                        ],
+                        [
+                            16,
+                            1
+                        ]
+                    ]
+                },
+                "fill-outline-color": "hsl(55, 3%, 87%)",
+                "fill-antialias": true
+            }
+        },
+        {
+            "id": "tunnel-street-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11.5,
+                            0
+                        ],
+                        [
+                            12,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-street_limited-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street_limited"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11.5,
+                            0
+                        ],
+                        [
+                            12,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-service-link-track-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "service",
+                    "track"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ]
+            }
+        },
+        {
+            "id": "tunnel-street_limited-case",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-street_limited-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ],
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-street-case",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-street-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ],
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-secondary-tertiary-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "secondary",
+                    "tertiary"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            2
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ],
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)"
+            }
+        },
+        {
+            "id": "tunnel-primary-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "primary"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ],
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)"
+            }
+        },
+        {
+            "id": "tunnel-trunk_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ]
+            }
+        },
+        {
+            "id": "tunnel-motorway_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    3,
+                    3
+                ]
+            }
+        },
+        {
+            "id": "tunnel-trunk-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-opacity": 1,
+                "line-dasharray": [
+                    3,
+                    3
+                ]
+            }
+        },
+        {
+            "id": "tunnel-motorway-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-opacity": 1,
+                "line-dasharray": [
+                    3,
+                    3
+                ]
+            }
+        },
+        {
+            "id": "tunnel-construction",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "construction"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                },
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                0.4,
+                                0.8
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                0.3,
+                                0.6
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                0.2,
+                                0.3
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.2,
+                                0.25
+                            ]
+                        ],
+                        [
+                            18,
+                            [
+                                0.15,
+                                0.15
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-path",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "path"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "steps"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                1,
+                                0.5
+                            ]
+                        ]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 85%)",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-steps",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "structure",
+                        "tunnel"
+                    ],
+                    [
+                        "==",
+                        "type",
+                        "steps"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 85%)",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.3,
+                                0.3
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-trunk_link",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-trunk_link-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [
+                    1,
+                    0
+                ]
+            }
+        },
+        {
+            "id": "tunnel-motorway_link",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-motorway_link-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [
+                    1,
+                    0
+                ]
+            }
+        },
+        {
+            "id": "tunnel-pedestrian",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "pedestrian"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "tunnel"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.5,
+                                0.4
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.2
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-service-link-track",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-service-link-track-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-dasharray": [
+                    1,
+                    0
+                ]
+            }
+        },
+        {
+            "id": "tunnel-street_limited",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-street_limited-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-street",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-street-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-secondary-tertiary",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-secondary-tertiary-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [
+                    1,
+                    0
+                ],
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "tunnel-primary",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-primary-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [
+                    1,
+                    0
+                ],
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "tunnel-trunk",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "hsl(187, 7%, 88%)"
+            }
+        },
+        {
+            "id": "tunnel-motorway",
+            "metadata": {
+                "mapbox:group": "1444855769305.6016"
+            },
+            "ref": "tunnel-motorway-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    1,
+                    0
+                ],
+                "line-opacity": 1,
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "road-pedestrian-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 12,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "pedestrian"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "none"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            14.5
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": 0,
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-street-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "street"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "none"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11,
+                            0
+                        ],
+                        [
+                            11.25,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-street_limited-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "street_limited"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "none"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11,
+                            0
+                        ],
+                        [
+                            11.25,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-service-link-track-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "service",
+                    "track"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-street_limited-case",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-street_limited-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-street-case",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-street-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-main-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "secondary",
+                    "tertiary"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-primary-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "primary"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-motorway_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 10,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-trunk_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            7,
+                            0.4
+                        ],
+                        [
+                            9,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-trunk-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 5,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            7,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.5
+                        ],
+                        [
+                            9,
+                            1.4
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            0
+                        ],
+                        [
+                            6.1,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-motorway-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            7,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            "hsl(156, 7%, 87%)"
+                        ],
+                        [
+                            11,
+                            "#e8edeb"
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-construction",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "construction"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "none"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                },
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                0.4,
+                                0.8
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                0.3,
+                                0.6
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                0.2,
+                                0.3
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.2,
+                                0.25
+                            ]
+                        ],
+                        [
+                            18,
+                            [
+                                0.15,
+                                0.15
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-sidewalks",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 16,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "!in",
+                        "structure",
+                        "bridge",
+                        "tunnel"
+                    ],
+                    [
+                        "in",
+                        "type",
+                        "crossing",
+                        "sidewalk"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                1,
+                                0.5
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            16,
+                            0
+                        ],
+                        [
+                            16.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-path",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "path"
+                    ],
+                    [
+                        "!in",
+                        "structure",
+                        "bridge",
+                        "tunnel"
+                    ],
+                    [
+                        "!in",
+                        "type",
+                        "crossing",
+                        "sidewalk",
+                        "steps"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                1,
+                                0.5
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-steps",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "!in",
+                        "structure",
+                        "bridge",
+                        "tunnel"
+                    ],
+                    [
+                        "==",
+                        "type",
+                        "steps"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.3,
+                                0.3
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-trunk_link",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-trunk_link-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-motorway_link",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-motorway_link-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-pedestrian",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-pedestrian-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.5,
+                                0.4
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.2
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-service-link-track",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "service",
+                    "track"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "road-street_limited",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-street_limited-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-street",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-street-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-secondary-tertiary",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-main-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-primary",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-primary-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-trunk",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-trunk-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.5
+                        ],
+                        [
+                            9,
+                            1.4
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-motorway",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "ref": "road-motorway-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-rail",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855786460.0557"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "major_rail",
+                    "minor_rail"
+                ],
+                [
+                    "!in",
+                    "structure",
+                    "bridge",
+                    "tunnel"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#e8edeb",
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0.75
+                        ],
+                        [
+                            20,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-pedestrian-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "class",
+                        "pedestrian"
+                    ],
+                    [
+                        "==",
+                        "structure",
+                        "bridge"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            14.5
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": 0,
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-street-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11.5,
+                            0
+                        ],
+                        [
+                            12,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-street_limited-low",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street_limited"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [
+                        [
+                            11.5,
+                            0
+                        ],
+                        [
+                            12,
+                            1
+                        ],
+                        [
+                            14,
+                            1
+                        ],
+                        [
+                            14.01,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-service-link-track-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "service",
+                    "track"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-street_limited-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street_limited"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-street-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "street"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            13,
+                            0
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-secondary-tertiary-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "secondary",
+                    "tertiary"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-translate": [
+                    0,
+                    0
+                ]
+            }
+        },
+        {
+            "id": "bridge-primary-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "primary"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-translate": [
+                    0,
+                    0
+                ]
+            }
+        },
+        {
+            "id": "bridge-trunk_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10.99,
+                            0
+                        ],
+                        [
+                            11,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-motorway_link-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    "<=",
+                    "layer",
+                    1
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "bridge-trunk-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-motorway-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            7,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-construction",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "construction"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                },
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                0.4,
+                                0.8
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                0.3,
+                                0.6
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                0.2,
+                                0.3
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.2,
+                                0.25
+                            ]
+                        ],
+                        [
+                            18,
+                            [
+                                0.15,
+                                0.15
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-path",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "path"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "steps"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                1,
+                                0.5
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-steps",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "all",
+                    [
+                        "==",
+                        "structure",
+                        "bridge"
+                    ],
+                    [
+                        "==",
+                        "type",
+                        "steps"
+                    ]
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            15,
+                            1
+                        ],
+                        [
+                            18,
+                            4
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.75,
+                                1
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.75
+                            ]
+                        ],
+                        [
+                            17,
+                            [
+                                0.3,
+                                0.3
+                            ]
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0
+                        ],
+                        [
+                            14.25,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-trunk_link",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "layer",
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway_link",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    "!in",
+                    "layer",
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-pedestrian",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "ref": "bridge-pedestrian-case",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            [
+                                1,
+                                0
+                            ]
+                        ],
+                        [
+                            15,
+                            [
+                                1.5,
+                                0.4
+                            ]
+                        ],
+                        [
+                            16,
+                            [
+                                1,
+                                0.2
+                            ]
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-service-link-track",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "service",
+                    "track"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "!=",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            14,
+                            0.5
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-street_limited",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "ref": "bridge-street_limited-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-street",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "ref": "bridge-street-low",
+            "interactive": true,
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12.5,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13.99,
+                            0
+                        ],
+                        [
+                            14,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-secondary-tertiary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "in",
+                    "type",
+                    "secondary",
+                    "tertiary"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            8.5,
+                            0.5
+                        ],
+                        [
+                            10,
+                            0.75
+                        ],
+                        [
+                            18,
+                            26
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-primary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "primary"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5.5,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-trunk",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    "!in",
+                    "layer",
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    "!in",
+                    "layer",
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "districts_boundary_line",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "districts",
+            "minzoom": 4,
+            "interactive": true,
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 11%)",
+                "line-offset": 0,
+                "line-opacity": 1,
+                "line-blur": 5
+            }
+        },
+        {
+            "id": "bridge-rail",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "class",
+                    "major_rail",
+                    "minor_rail"
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#e8edeb",
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0.75
+                        ],
+                        [
+                            20,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-trunk_link-2-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10.99,
+                            0
+                        ],
+                        [
+                            11,
+                            1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-motorway_link-2-case copy",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.75
+                        ],
+                        [
+                            20,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "bridge-trunk-2-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-motorway-2-case",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            7,
+                            0.5
+                        ],
+                        [
+                            10,
+                            1
+                        ],
+                        [
+                            16,
+                            2
+                        ]
+                    ]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-trunk_link-2",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ],
+                [
+                    "==",
+                    "type",
+                    "trunk_link"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway_link-2",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway_link"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            12,
+                            0.5
+                        ],
+                        [
+                            14,
+                            2
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-trunk-2",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "trunk"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway-2",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444855799204.86"
+            },
+            "source": "composite",
+            "source-layer": "road",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "class",
+                    "motorway"
+                ],
+                [
+                    ">=",
+                    "layer",
+                    2
+                ],
+                [
+                    "==",
+                    "structure",
+                    "bridge"
+                ]
+            ],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [
+                        [
+                            5,
+                            0.75
+                        ],
+                        [
+                            18,
+                            32
+                        ]
+                    ]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "admin-3-4-boundaries-bg",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934295202.7542"
+            },
+            "source": "composite",
+            "source-layer": "admin",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    ">=",
+                    "admin_level",
+                    3
+                ],
+                [
+                    "==",
+                    "maritime",
+                    0
+                ]
+            ],
+            "layout": {
+                "line-join": "bevel"
+            },
+            "paint": {
+                "line-color": "hsl(0, 0%, 84%)",
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            3.5
+                        ],
+                        [
+                            10,
+                            8
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            4,
+                            0
+                        ],
+                        [
+                            7,
+                            0.5
+                        ],
+                        [
+                            8,
+                            0.75
+                        ]
+                    ]
+                },
+                "line-dasharray": [
+                    1,
+                    0
+                ],
+                "line-translate": [
+                    0,
+                    0
+                ],
+                "line-blur": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            0
+                        ],
+                        [
+                            8,
+                            3
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "admin-2-boundaries-bg",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934295202.7542"
+            },
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "admin_level",
+                    2
+                ],
+                [
+                    "==",
+                    "maritime",
+                    0
+                ]
+            ],
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            3.5
+                        ],
+                        [
+                            10,
+                            10
+                        ]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 84%)",
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            0
+                        ],
+                        [
+                            4,
+                            0.5
+                        ]
+                    ]
+                },
+                "line-translate": [
+                    0,
+                    0
+                ],
+                "line-blur": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            0
+                        ],
+                        [
+                            10,
+                            2
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "admin-3-4-boundaries",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934295202.7542"
+            },
+            "source": "composite",
+            "source-layer": "admin",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    ">=",
+                    "admin_level",
+                    3
+                ],
+                [
+                    "==",
+                    "maritime",
+                    0
+                ]
+            ],
+            "layout": {
+                "line-join": "round",
+                "line-cap": "round"
+            },
+            "paint": {
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            [
+                                2,
+                                0
+                            ]
+                        ],
+                        [
+                            7,
+                            [
+                                2,
+                                2,
+                                6,
+                                2
+                            ]
+                        ]
+                    ]
+                },
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            0.75
+                        ],
+                        [
+                            12,
+                            1.5
+                        ]
+                    ]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            2,
+                            0
+                        ],
+                        [
+                            3,
+                            1
+                        ]
+                    ]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            4,
+                            "hsl(0, 0%, 80%)"
+                        ],
+                        [
+                            5,
+                            "hsl(0, 0%, 70%)"
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "admin-2-boundaries",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934295202.7542"
+            },
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "admin_level",
+                    2
+                ],
+                [
+                    "==",
+                    "disputed",
+                    0
+                ],
+                [
+                    "==",
+                    "maritime",
+                    0
+                ]
+            ],
+            "layout": {
+                "line-join": "round",
+                "line-cap": "round"
+            },
+            "paint": {
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            "hsl(0, 0%, 70%)"
+                        ],
+                        [
+                            4,
+                            "hsl(0, 0%, 62%)"
+                        ]
+                    ]
+                },
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            0.5
+                        ],
+                        [
+                            10,
+                            2
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "admin-2-boundaries-dispute",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1444934295202.7542"
+            },
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "admin_level",
+                    2
+                ],
+                [
+                    "==",
+                    "disputed",
+                    1
+                ],
+                [
+                    "==",
+                    "maritime",
+                    0
+                ]
+            ],
+            "layout": {
+                "line-join": "round"
+            },
+            "paint": {
+                "line-dasharray": [
+                    1.5,
+                    1.5
+                ],
+                "line-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            "hsl(0, 0%, 70%)"
+                        ],
+                        [
+                            4,
+                            "hsl(0, 0%, 62%)"
+                        ]
+                    ]
+                },
+                "line-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            0.5
+                        ],
+                        [
+                            10,
+                            2
+                        ]
+                    ]
+                }
+            }
+        },
+	 {
             "id": "districts_5_boundary",
             "type": "line",
             "metadata": {
@@ -893,3963 +6866,689 @@
             }
         },
         {
-            "id": "shadow_uber",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 15,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                56
-            ],
-            "paint": {
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.1
-                        ],
-                        [
-                            15,
-                            0
-                        ]
-                    ]
-                },
-                "fill-color": "hsl(357, 2%, 76%)"
-            }
-        },
-        {
-            "id": "shadow_strong",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 15,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                67
-            ],
-            "paint": {
-                "fill-opacity": 0.1,
-                "fill-color": "hsl(357, 2%, 76%)"
-            }
-        },
-        {
-            "id": "shadow_medium",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 15,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                78
-            ],
-            "paint": {
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.07
-                        ],
-                        [
-                            15,
-                            0
-                        ]
-                    ]
-                },
-                "fill-color": "hsl(357, 2%, 76%)"
-            }
-        },
-        {
-            "id": "shadow_weak",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 15,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                89
-            ],
-            "paint": {
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.07
-                        ],
-                        [
-                            15,
-                            0
-                        ]
-                    ]
-                },
-                "fill-color": "hsl(357, 2%, 76%)"
-            }
-        },
-        {
-            "id": "highlight_weak",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 15,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                90
-            ],
-            "paint": {
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14,
-                            0.1
-                        ],
-                        [
-                            15,
-                            0
-                        ]
-                    ]
-                },
-                "fill-color": "#fff"
-            }
-        },
-        {
-            "id": "highlight_medium",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858181796.6055"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                94
-            ],
-            "paint": {
-                "fill-color": "#fff",
-                "fill-opacity": 0.2
-            }
-        },
-        {
-            "id": "airport_runway",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858189651.4805"
-            },
-            "source": "composite",
-            "source-layer": "aeroway",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "runway"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            6,
-                            2
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": 0.8,
-                "line-color": "#d0d1cf"
-            }
-        },
-        {
-            "id": "airport_taxiway",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858189651.4805"
-            },
-            "source": "composite",
-            "source-layer": "aeroway",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "==",
-                    "type",
-                    "taxiway"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            6,
-                            1
-                        ],
-                        [
-                            20,
-                            12
-                        ]
-                    ]
-                },
-                "line-opacity": 0.8,
-                "line-color": "hsl(82, 2%, 82%)"
-            }
-        },
-        {
-            "id": "barrier_land",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858470265.9292"
-            },
-            "source": "composite",
-            "source-layer": "barrier_line",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "Polygon"
-                ],
-                [
-                    "in",
-                    "class",
-                    "land",
-                    "cliff"
-                ]
-            ],
-            "paint": {
-                "fill-color": "#F8F4F0",
-                "fill-opacity": 1
-            }
-        },
-        {
-            "id": "building_roofs",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1444858216876.1328"
-            },
-            "source": "composite",
-            "source-layer": "building",
-            "interactive": true,
-            "paint": {
-                "fill-color": "hsl(0, 0%, 99%)",
-                "fill-translate": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            [
-                                0,
-                                0
-                            ]
-                        ],
-                        [
-                            19,
-                            [
-                                -4,
-                                -4
-                            ]
-                        ]
-                    ]
-                },
-                "fill-opacity": 0.65
-            }
-        },
-        {
-            "id": "building_roof_edges",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858216876.1328"
-            },
-            "source": "composite",
-            "source-layer": "building",
-            "interactive": true,
-            "paint": {
-                "line-color": "hsl(0, 0%, 45%)",
-                "line-width": 0.75,
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14.95,
-                            0
-                        ],
-                        [
-                            18,
-                            1
-                        ]
-                    ]
-                },
-                "line-translate": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            [
-                                -0.25,
-                                -0.25
-                            ]
-                        ],
-                        [
-                            19,
-                            [
-                                -4,
-                                -4
-                            ]
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "country_border",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858269512.7246"
-            },
-            "source": "composite",
-            "source-layer": "admin",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "admin_level",
-                    2
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ],
-                [
-                    "==",
-                    "disputed",
-                    0
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt"
-            },
-            "paint": {
-                "line-color": "#293804",
-                "line-opacity": 0.5,
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            0.5
-                        ],
-                        [
-                            10,
-                            2
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "country_border_disputed",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858269512.7246"
-            },
-            "source": "composite",
-            "source-layer": "admin",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "admin_level",
-                    2
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ],
-                [
-                    "==",
-                    "disputed",
-                    1
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt"
-            },
-            "paint": {
-                "line-color": "#293804",
-                "line-opacity": 0.5,
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            0.5
-                        ],
-                        [
-                            10,
-                            2
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    2,
-                    2
-                ]
-            }
-        },
-        {
-            "id": "state_border",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858269512.7246"
-            },
-            "source": "composite",
-            "source-layer": "admin",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "admin_level",
-                    4
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt"
-            },
-            "paint": {
-                "line-color": "hsl(0, 0%, 53%)",
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            3.5,
-                            1
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            0.75
-                        ],
-                        [
-                            13,
-                            4
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    3,
-                    1
-                ]
-            }
-        },
-        {
-            "id": "tunnel_path",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "path"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsla(24, 1%, 38%, 0.52)",
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            20,
-                            3.5
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.3,
-                    2.5
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15,
-                            0
-                        ],
-                        [
-                            15.25,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_service_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14.05,
-                            "#ddd1d3"
-                        ],
-                        [
-                            16.1,
-                            "#cdbebc"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            15.05,
-                            2.5
-                        ],
-                        [
-                            15.1,
-                            5.5
-                        ],
-                        [
-                            20,
-                            32
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ],
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "tunnel_street_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "in",
-                        "class",
-                        "street",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "#F5F0e9"
-                        ],
-                        [
-                            13,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12.99,
-                            0
-                        ],
-                        [
-                            13,
-                            2.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ],
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "tunnel_tertiary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ],
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.9,
-                            "#F5F0e9"
-                        ],
-                        [
-                            12,
-                            "#cbbcb9"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            55
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ]
-            }
-        },
-        {
-            "id": "tunnel_secondary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ],
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "#F5F0e9"
-                        ],
-                        [
-                            10,
-                            "#cbbcb9"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9.95,
-                            0.75
-                        ],
-                        [
-                            10,
-                            2
-                        ],
-                        [
-                            20,
-                            66
-                        ]
-                    ]
-                },
-                "line-opacity": 1,
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ]
-            }
-        },
-        {
-            "id": "tunnel_trunk_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(212,194,146,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10.95,
-                            0
-                        ],
-                        [
-                            11,
-                            2.5
-                        ],
-                        [
-                            20,
-                            70
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ]
-            }
-        },
-        {
-            "id": "construction_tunnel",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "==",
-                "type",
-                "construction"
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14.05,
-                            0
-                        ],
-                        [
-                            14.1,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-opacity": 0.25,
-                "line-color": "#ccc",
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            }
-        },
-        {
-            "id": "tunnel_service",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-miter-limit": 2,
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "#fff",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15.05,
-                            0
-                        ],
-                        [
-                            15.1,
-                            3.25
-                        ],
-                        [
-                            20,
-                            20
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_street",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "in",
-                        "class",
-                        "street",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "tunnel"
-                    ]
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "#dfd3d5"
-                        ],
-                        [
-                            13,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11,
-                            0.5
-                        ],
-                        [
-                            12.99,
-                            1.25
-                        ],
-                        [
-                            13,
-                            1.75
-                        ],
-                        [
-                            20,
-                            30
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_tertiary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ],
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 66%)"
-                        ],
-                        [
-                            12,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.2,
-                            1.25
-                        ],
-                        [
-                            11,
-                            0.5
-                        ],
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            1.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_secondary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ],
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "#dfd3d5"
-                        ],
-                        [
-                            10,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_trunk",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.95,
-                            "hsl(0, 0%, 99%)"
-                        ],
-                        [
-                            11,
-                            "rgba(255,242,194,1)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            6,
-                            0.75
-                        ],
-                        [
-                            11,
-                            1.25
-                        ],
-                        [
-                            20,
-                            54
-                        ]
-                    ]
-                },
-                "line-gap-width": 0,
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_motorway_link_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway_link"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ],
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_motorway_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "square",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9.95,
-                            0
-                        ],
-                        [
-                            10,
-                            2.5
-                        ],
-                        [
-                            20,
-                            72
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.5,
-                    0.5
-                ],
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_motorway_link",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway_link"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            12,
-                            "hsl(22, 71%, 93%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.7
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            20,
-                            36
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "tunnel_motorway",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858143444.556"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "tunnel"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            10,
-                            "hsl(31, 91%, 89%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            1.75
-                        ],
-                        [
-                            9.95,
-                            2.5
-                        ],
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            56
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "railroad",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "major_rail",
-                "minor_rail"
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsl(0, 0%, 67%)",
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            1
-                        ],
-                        [
-                            20,
-                            2.5
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "railroad_hashes",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "major_rail",
-                "minor_rail"
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsl(0, 0%, 67%)",
-                "line-width": {
-                    "base": 1.49,
-                    "stops": [
-                        [
-                            5,
-                            0.5
-                        ],
-                        [
-                            16,
-                            10
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.15,
-                    1.95
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "path",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "in",
-                    "class",
-                    "path",
-                    "pedestrian"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsla(24, 1%, 38%, 0.53)",
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            20,
-                            3.5
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.3,
-                    2.5
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15,
-                            0
-                        ],
-                        [
-                            15.25,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "service_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15.05,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            15.1,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            15.05,
-                            2.5
-                        ],
-                        [
-                            15.1,
-                            5.5
-                        ],
-                        [
-                            20,
-                            32
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "street_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "in",
-                        "class",
-                        "street",
-                        "street_limited",
-                        "link"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "none"
-                    ]
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "#F5F0e9"
-                        ],
-                        [
-                            13,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12.99,
-                            0
-                        ],
-                        [
-                            13,
-                            2.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "tertiary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.9,
-                            "#F5F0e9"
-                        ],
-                        [
-                            12,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            59
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.5,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "secondary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ],
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.95,
-                            "#F5F0e9"
-                        ],
-                        [
-                            11,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10.95,
-                            0.75
-                        ],
-                        [
-                            11,
-                            2.75
-                        ],
-                        [
-                            20,
-                            66
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "construction_road",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "ref": "construction_tunnel",
-            "interactive": true,
-            "paint": {
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            14.05,
-                            0
-                        ],
-                        [
-                            14.1,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-opacity": 0.25,
-                "line-color": "#ccc",
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            }
-        },
-        {
-            "id": "trunk_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "type",
-                    "trunk",
-                    "primary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": "rgba(212,194,146,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10.95,
-                            0
-                        ],
-                        [
-                            11,
-                            2.5
-                        ],
-                        [
-                            20,
-                            70
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0
-                        ],
-                        [
-                            8.5,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "service",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "#fff",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15.05,
-                            0
-                        ],
-                        [
-                            15.1,
-                            3.25
-                        ],
-                        [
-                            20,
-                            20
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "street",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "ref": "street_case",
-            "interactive": true,
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "hsla(15, 100%, 100%, 0.44)"
-                        ],
-                        [
-                            13,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11,
-                            0.5
-                        ],
-                        [
-                            12.99,
-                            1.25
-                        ],
-                        [
-                            13,
-                            1.75
-                        ],
-                        [
-                            20,
-                            30
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "tertiary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            12,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.2,
-                            1.25
-                        ],
-                        [
-                            11,
-                            0.75
-                        ],
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            1.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "secondary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": "#fff",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "trunk",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.95,
-                            "hsl(0, 0%, 99%)"
-                        ],
-                        [
-                            11,
-                            "hsl(47, 100%, 95%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            7,
-                            0.5
-                        ],
-                        [
-                            11,
-                            1.25
-                        ],
-                        [
-                            20,
-                            54
-                        ]
-                    ]
-                },
-                "line-gap-width": 0,
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "motorway_link_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway_link"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "motorway_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "none"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9.95,
-                            0
-                        ],
-                        [
-                            10,
-                            2.5
-                        ],
-                        [
-                            20,
-                            72
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "motorway_link",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "ref": "motorway_link_case",
-            "interactive": true,
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            12,
-                            "hsl(22, 71%, 93%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.7
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            20,
-                            36
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "motorway",
-            "metadata": {
-                "mapbox:group": "1444858128913.9963"
-            },
-            "ref": "motorway_case",
-            "interactive": true,
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            10,
-                            "hsl(31, 91%, 89%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            1
-                        ],
-                        [
-                            9.95,
-                            2.5
-                        ],
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            56
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "state-label",
+            "id": "waterway-label",
             "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858262202.7446"
-            },
-            "source": "composite",
-            "source-layer": "state_label",
-            "minzoom": 3,
-            "interactive": true,
-            "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            1
-                        ],
-                        [
-                            12,
-                            35
-                        ]
-                    ]
-                },
-                "text-allow-overlap": true,
-                "text-transform": "uppercase",
-                "text-font": [
-                    "Open Sans Bold",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 0,
-                "text-field": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "{abbr}"
-                        ],
-                        [
-                            6,
-                            "{name}"
-                        ]
-                    ]
-                },
-                "text-letter-spacing": 0.15,
-                "text-max-width": 4
-            },
-            "paint": {
-                "text-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            3.5,
-                            0.5
-                        ]
-                    ]
-                },
-                "text-color": "hsl(0, 0%, 0%)"
-            }
-        },
-        {
-            "id": "districts_boundary_line",
-            "type": "line",
-            "source": "composite",
-            "source-layer": "districts",
-            "minzoom": 4,
-            "interactive": true,
-            "layout": {
-                "line-join": "miter"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "hsl(0, 0%, 11%)",
-                "line-offset": 0,
-                "line-opacity": 1,
-                "line-blur": 5
-            }
-        },
-        {
-            "id": "bridge_railroad",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "class",
-                    "major_rail",
-                    "minor_rail"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsl(0, 0%, 67%)",
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            1
-                        ],
-                        [
-                            20,
-                            2.5
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_railroad_hashes",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "class",
-                    "major_rail",
-                    "minor_rail"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsl(0, 0%, 67%)",
-                "line-width": {
-                    "base": 1.49,
-                    "stops": [
-                        [
-                            5,
-                            0.5
-                        ],
-                        [
-                            16,
-                            8
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.15,
-                    1.95
-                ],
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11,
-                            0
-                        ],
-                        [
-                            14,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_service_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15.05,
-                            "#ddd1d3"
-                        ],
-                        [
-                            15.1,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            15.05,
-                            2.5
-                        ],
-                        [
-                            15.1,
-                            5.5
-                        ],
-                        [
-                            20,
-                            32
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_street_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "in",
-                        "class",
-                        "street",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "#F5F0e9"
-                        ],
-                        [
-                            13,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            12.99,
-                            0
-                        ],
-                        [
-                            13,
-                            2.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "bridge_tertiary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.9,
-                            "#F5F0e9"
-                        ],
-                        [
-                            12,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            59
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.5,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_secondary_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "#F5F0e9"
-                        ],
-                        [
-                            10,
-                            "#d2c6c6"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9.95,
-                            0.75
-                        ],
-                        [
-                            10,
-                            2
-                        ],
-                        [
-                            20,
-                            66
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0
-                        ],
-                        [
-                            8.5,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_trunk_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(212,194,146,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10.95,
-                            0
-                        ],
-                        [
-                            11,
-                            2.5
-                        ],
-                        [
-                            20,
-                            70
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0
-                        ],
-                        [
-                            8.5,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "construction_bridge",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "type",
-                    "construction"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.05,
-                            0
-                        ],
-                        [
-                            12.1,
-                            2
-                        ],
-                        [
-                            18,
-                            7
-                        ]
-                    ]
-                },
-                "line-opacity": 0.25,
-                "line-color": "#ccc",
-                "line-dasharray": [
-                    1,
-                    0
-                ]
-            }
-        },
-        {
-            "id": "bridge_service",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "service"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "#fff",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            15.05,
-                            0
-                        ],
-                        [
-                            15.1,
-                            3.25
-                        ],
-                        [
-                            20,
-                            20
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_street",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "$type",
-                    "LineString"
-                ],
-                [
-                    "all",
-                    [
-                        "in",
-                        "class",
-                        "street",
-                        "street_limited"
-                    ],
-                    [
-                        "==",
-                        "structure",
-                        "bridge"
-                    ]
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12.99,
-                            "#dfd3d5"
-                        ],
-                        [
-                            13,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11,
-                            0.5
-                        ],
-                        [
-                            12.99,
-                            1.25
-                        ],
-                        [
-                            13,
-                            1.75
-                        ],
-                        [
-                            20,
-                            30
-                        ]
-                    ]
-                },
-                "line-opacity": 1
-            }
-        },
-        {
-            "id": "bridge_tertiary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "==",
-                    "class",
-                    "tertiary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 66%)"
-                        ],
-                        [
-                            12,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            5.2,
-                            1.25
-                        ],
-                        [
-                            11,
-                            0.75
-                        ],
-                        [
-                            11.95,
-                            0.5
-                        ],
-                        [
-                            12,
-                            1.75
-                        ],
-                        [
-                            20,
-                            44
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_secondary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "minzoom": 11,
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "==",
-                    "class",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "#dfd3d5"
-                        ],
-                        [
-                            10,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_trunk",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ],
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round",
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10.95,
-                            "hsl(0, 0%, 99%)"
-                        ],
-                        [
-                            11,
-                            "rgba(255,242,194,1)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            6,
-                            0.75
-                        ],
-                        [
-                            11,
-                            1.25
-                        ],
-                        [
-                            20,
-                            54
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_motorway_link_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway_link"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0
-                        ],
-                        [
-                            12,
-                            3
-                        ],
-                        [
-                            20,
-                            50
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_motorway_case",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "rgba(225,162,102,1)",
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            9.95,
-                            0
-                        ],
-                        [
-                            10,
-                            2.5
-                        ],
-                        [
-                            20,
-                            72
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_path",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "path"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": "hsla(24, 1%, 38%, 0.52)",
-                "line-width": {
-                    "base": 1.25,
-                    "stops": [
-                        [
-                            5,
-                            0.75
-                        ],
-                        [
-                            20,
-                            3.5
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    0.3,
-                    2.5
-                ],
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_motorway_link",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway_link"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            11.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            12,
-                            "hsl(22, 71%, 93%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11.95,
-                            0.7
-                        ],
-                        [
-                            12,
-                            1
-                        ],
-                        [
-                            20,
-                            36
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "bridge_motorway",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1444858082697.2502"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "==",
-                    "structure",
-                    "bridge"
-                ]
-            ],
-            "layout": {
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "paint": {
-                "line-color": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            9.95,
-                            "hsl(0, 0%, 100%)"
-                        ],
-                        [
-                            10,
-                            "hsl(31, 91%, 89%)"
-                        ]
-                    ]
-                },
-                "line-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            2,
-                            1.75
-                        ],
-                        [
-                            9.95,
-                            2.5
-                        ],
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            56
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 0.7,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            11,
-                            1
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "river_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858096986.3894"
-            },
             "source": "composite",
             "source-layer": "waterway_label",
+            "minzoom": 12,
             "interactive": true,
             "filter": [
-                "==",
-                "type",
+                "in",
+                "class",
+                "canal",
                 "river"
             ],
             "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1
-                        ],
-                        [
-                            20,
-                            1.75
-                        ]
-                    ]
-                },
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-max-angle": 30,
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            6,
-                            8
+                            13,
+                            12
+                        ],
+                        [
+                            18,
+                            16
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-width": 0,
+                "text-halo-blur": 0,
+                "text-color": "#78888a"
+            }
+        },
+        {
+            "id": "poi-scalerank3",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933372896.5967"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "==",
+                    "scalerank",
+                    3
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            16,
+                            11
+                        ],
+                        [
+                            20,
+                            13
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 1,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-parks-scalerank3",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933372896.5967"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "==",
+                    "scalerank",
+                    3
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            16,
+                            11
+                        ],
+                        [
+                            20,
+                            12
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-halo-blur": 0,
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-color": "#949494"
+            }
+        },
+        {
+            "id": "road-label-small",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933721429.3076"
+            },
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 15,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "!in",
+                    "class",
+                    "",
+                    "ferry",
+                    "link",
+                    "motorway",
+                    "path",
+                    "pedestrian",
+                    "primary",
+                    "secondary",
+                    "street",
+                    "street_limited",
+                    "tertiary",
+                    "track",
+                    "trunk"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            15,
+                            10
+                        ],
+                        [
+                            20,
+                            13
+                        ]
+                    ]
+                },
+                "text-max-angle": 30,
+                "symbol-spacing": 500,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-rotation-alignment": "map",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "road-label-medium",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933721429.3076"
+            },
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 13,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "in",
+                    "class",
+                    "",
+                    "link",
+                    "pedestrian",
+                    "street",
+                    "street_limited"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            11,
+                            10
+                        ],
+                        [
+                            20,
+                            14
+                        ]
+                    ]
+                },
+                "text-max-angle": 30,
+                "symbol-spacing": 500,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-rotation-alignment": "map",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "road-label-large",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933721429.3076"
+            },
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 12,
+            "interactive": true,
+            "filter": [
+                "in",
+                "class",
+                "motorway",
+                "primary",
+                "secondary",
+                "tertiary",
+                "trunk"
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            9,
+                            10
+                        ],
+                        [
+                            20,
+                            16
+                        ]
+                    ]
+                },
+                "text-max-angle": 30,
+                "symbol-spacing": 400,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-rotation-alignment": "map",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "rgba(255,255,255, 0.75)",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-scalerank2",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933358918.2366"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "==",
+                    "scalerank",
+                    2
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            11
+                        ],
+                        [
+                            20,
+                            12
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-parks-scalerank2",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933358918.2366"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "==",
+                    "scalerank",
+                    2
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            11
+                        ],
+                        [
+                            20,
+                            12
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "water-label",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933808272.805"
+            },
+            "source": "composite",
+            "source-layer": "water_label",
+            "minzoom": 5,
+            "interactive": true,
+            "filter": [
+                ">",
+                "area",
+                10000
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-max-width": 7,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            13,
+                            13
+                        ],
+                        [
+                            18,
+                            18
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-color": "#78888a",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-parks-scalerank1",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933322393.2852"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "<=",
+                    "scalerank",
+                    1
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            11
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 58%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-scalerank1",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444933322393.2852"
+            },
+            "source": "composite",
+            "source-layer": "poi_label",
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                [
+                    "<=",
+                    "scalerank",
+                    1
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            11
+                        ],
+                        [
+                            18,
+                            12
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 58%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "airport-label",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "airport_label",
+            "minzoom": 10,
+            "interactive": true,
+            "filter": [
+                "<=",
+                "scalerank",
+                2
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            12
                         ],
                         [
                             18,
@@ -4857,91 +7556,864 @@
                         ]
                     ]
                 },
-                "text-max-angle": 15,
-                "symbol-spacing": 550,
+                "symbol-spacing": 250,
                 "text-font": [
-                    "Open Sans Semibold Italic",
+                    "DIN Offc Pro Medium",
                     "Arial Unicode MS Regular"
                 ],
-                "symbol-placement": "line",
-                "text-padding": 10,
-                "text-rotation-alignment": "map",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.3,
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "hsl(204, 22%, 55%)",
-                "text-halo-color": "#F8F4F0",
-                "text-halo-width": 0
-            }
-        },
-        {
-            "id": "marine_label_big",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858096986.3894"
-            },
-            "source": "composite",
-            "source-layer": "marine_label",
-            "interactive": true,
-            "filter": [
-                "<=",
-                "labelrank",
-                1
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
+                "text-padding": 2,
+                "text-anchor": "center",
+                "text-field": {
                     "stops": [
                         [
-                            0,
-                            1.25
+                            11,
+                            "{ref}"
                         ],
                         [
-                            20,
-                            1.75
+                            14,
+                            "{name_en}"
                         ]
                     ]
                 },
+                "text-letter-spacing": 0.01,
+                "text-max-width": 9
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 0.5,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-islets-archipelago-aboriginal",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "in",
+                "type",
+                "aboriginal_lands",
+                "archipelago",
+                "islet"
+            ],
+            "layout": {
+                "text-line-height": 1.2,
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            2,
-                            13
+                            10,
+                            11
                         ],
                         [
                             18,
-                            29
+                            16
                         ]
                     ]
                 },
-                "text-max-angle": 15,
-                "symbol-spacing": 550,
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
                 "text-font": [
-                    "Open Sans Semibold Italic",
+                    "DIN Offc Pro Regular",
                     "Arial Unicode MS Regular"
                 ],
-                "text-padding": 10,
-                "text-field": "{name}",
-                "text-letter-spacing": 0.3,
-                "text-max-width": 5
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
             },
             "paint": {
-                "text-color": "hsl(204, 22%, 55%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 0
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "marine_label_medium_linear",
+            "id": "place-neighbourhood",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 12,
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "neighbourhood"
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-transform": "uppercase",
+                "text-letter-spacing": 0.1,
+                "text-max-width": 7,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 3,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            12,
+                            11
+                        ],
+                        [
+                            16,
+                            16
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-width": 1,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-suburb",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 11,
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "suburb"
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-transform": "uppercase",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-letter-spacing": 0.15,
+                "text-max-width": 7,
+                "text-padding": 3,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            11,
+                            11
+                        ],
+                        [
+                            15,
+                            18
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-width": 1,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-hamlet",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 10,
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "hamlet"
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            12,
+                            11.5
+                        ],
+                        [
+                            15,
+                            16
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-village",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 11,
+            "maxzoom": 15,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "village"
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-max-width": 7,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            11.5
+                        ],
+                        [
+                            16,
+                            18
+                        ]
+                    ]
+                },
+                "text-offset": [
+                    0,
+                    0
+                ]
+            },
+            "paint": {
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            "hsl(0, 0%, 62%)"
+                        ],
+                        [
+                            11,
+                            "hsl(0, 0%, 55%)"
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-town",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 7,
+            "maxzoom": 15,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "town"
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            11.5
+                        ],
+                        [
+                            15,
+                            20
+                        ]
+                    ]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            11,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            12,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                },
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            "hsl(0, 0%, 62%)"
+                        ],
+                        [
+                            11,
+                            "hsl(0, 0%, 55%)"
+                        ]
+                    ]
+                },
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-islands",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 16,
+            "interactive": true,
+            "filter": [
+                "==",
+                "type",
+                "island"
+            ],
+            "layout": {
+                "text-line-height": 1.2,
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            10,
+                            11
+                        ],
+                        [
+                            18,
+                            16
+                        ]
+                    ]
+                },
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-sm",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858096986.3894"
+                "mapbox:group": "1444862510685.128"
+            },
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "scalerank",
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "type",
+                    "city"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            6,
+                            12
+                        ],
+                        [
+                            14,
+                            22
+                        ]
+                    ]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            8,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                },
+                "text-offset": [
+                    0,
+                    0
+                ],
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-md-s",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444862510685.128"
+            },
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "ldir",
+                    "E",
+                    "S",
+                    "SE",
+                    "SW"
+                ],
+                [
+                    "in",
+                    "scalerank",
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "type",
+                    "city"
+                ]
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-size": {
+                    "base": 0.9,
+                    "stops": [
+                        [
+                            5,
+                            12
+                        ],
+                        [
+                            12,
+                            22
+                        ]
+                    ]
+                },
+                "text-anchor": "center",
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            8,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-width": 1,
+                "text-halo-color": "#ffffff",
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-blur": 0,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "place-city-md-n",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444862510685.128"
+            },
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "ldir",
+                    "N",
+                    "NE",
+                    "NW",
+                    "W"
+                ],
+                [
+                    "in",
+                    "scalerank",
+                    3,
+                    4,
+                    5
+                ],
+                [
+                    "==",
+                    "type",
+                    "city"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 0.9,
+                    "stops": [
+                        [
+                            5,
+                            12
+                        ],
+                        [
+                            12,
+                            22
+                        ]
+                    ]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            8,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                },
+                "text-anchor": "center",
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-lg-s",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444862510685.128"
+            },
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 1,
+            "maxzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "ldir",
+                    "E",
+                    "S",
+                    "SE",
+                    "SW"
+                ],
+                [
+                    "<=",
+                    "scalerank",
+                    2
+                ],
+                [
+                    "==",
+                    "type",
+                    "city"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 0.9,
+                    "stops": [
+                        [
+                            4,
+                            12
+                        ],
+                        [
+                            10,
+                            22
+                        ]
+                    ]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            8,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                },
+                "icon-size": 1,
+                "text-anchor": "center",
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-lg-n",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444862510685.128"
+            },
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 1,
+            "maxzoom": 14,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "in",
+                    "ldir",
+                    "N",
+                    "NE",
+                    "NW",
+                    "W"
+                ],
+                [
+                    "<=",
+                    "scalerank",
+                    2
+                ],
+                [
+                    "==",
+                    "type",
+                    "city"
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 0.9,
+                    "stops": [
+                        [
+                            4,
+                            12
+                        ],
+                        [
+                            10,
+                            22
+                        ]
+                    ]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            [
+                                "DIN Offc Pro Regular",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ],
+                        [
+                            8,
+                            [
+                                "DIN Offc Pro Medium",
+                                "Arial Unicode MS Regular"
+                            ]
+                        ]
+                    ]
+                },
+                "icon-size": 1,
+                "text-anchor": "center",
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-opacity": 1,
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7.99,
+                            1
+                        ],
+                        [
+                            8,
+                            0
+                        ]
+                    ]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "marine-label-sm-ln",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444856087950.3635"
             },
             "source": "composite",
             "source-layer": "marine_label",
+            "minzoom": 3,
+            "maxzoom": 10,
             "interactive": true,
             "filter": [
                 "all",
@@ -4951,65 +8423,63 @@
                     "LineString"
                 ],
                 [
-                    ">",
+                    ">=",
                     "labelrank",
-                    2
+                    4
                 ]
             ],
             "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            1.25
-                        ],
-                        [
-                            20,
-                            1.75
-                        ]
-                    ]
-                },
+                "text-line-height": 1.1,
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            4,
-                            14
+                            3,
+                            12
                         ],
                         [
-                            20,
-                            24
+                            6,
+                            16
                         ]
                     ]
                 },
-                "text-max-angle": 45,
-                "symbol-spacing": 400,
+                "symbol-spacing": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            4,
+                            100
+                        ],
+                        [
+                            6,
+                            400
+                        ]
+                    ]
+                },
                 "text-font": [
-                    "Open Sans Semibold Italic",
+                    "DIN Offc Pro Italic",
                     "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
-                "text-padding": 10,
-                "text-rotation-alignment": "map",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.2,
-                "text-max-width": 7.5
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.1,
+                "text-max-width": 5
             },
             "paint": {
-                "text-color": "hsl(204, 22%, 55%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 0
+                "text-color": "#78888a",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "marine_label_medium_point",
+            "id": "marine-label-sm-pt",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858096986.3894"
+                "mapbox:group": "1444856087950.3635"
             },
             "source": "composite",
             "source-layer": "marine_label",
+            "minzoom": 3,
+            "maxzoom": 10,
             "interactive": true,
             "filter": [
                 "all",
@@ -5019,352 +8489,49 @@
                     "Point"
                 ],
                 [
-                    ">",
+                    ">=",
                     "labelrank",
-                    2
+                    4
                 ]
             ],
             "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            1.25
-                        ],
-                        [
-                            20,
-                            1.75
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            14
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ]
-                },
-                "text-max-angle": 45,
-                "symbol-spacing": 400,
-                "text-font": [
-                    "Open Sans Semibold Italic",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 10,
-                "text-rotation-alignment": "map",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.2,
-                "text-max-width": 7.5
-            },
-            "paint": {
-                "text-color": "hsl(204, 22%, 55%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 0
-            }
-        },
-        {
-            "id": "country_label_small",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858398532.1323"
-            },
-            "source": "composite",
-            "source-layer": "country_label",
-            "interactive": true,
-            "filter": [
-                ">",
-                "scalerank",
-                2
-            ],
-            "layout": {
-                "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            0,
-                            7
-                        ],
-                        [
-                            10,
-                            36
-                        ]
-                    ]
-                },
-                "text-transform": "none",
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
                 "text-field": "{name_en}",
-                "text-letter-spacing": 0.05,
-                "text-max-width": 4
-            },
-            "paint": {
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 2,
-                "text-color": "#2d1617"
-            }
-        },
-        {
-            "id": "country_label_big",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858398532.1323"
-            },
-            "source": "composite",
-            "source-layer": "country_label",
-            "interactive": true,
-            "filter": [
-                "<=",
-                "scalerank",
-                2
-            ],
-            "layout": {
-                "text-line-height": 1.1,
-                "text-size": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0,
-                            8
-                        ],
-                        [
-                            10,
-                            36
-                        ]
-                    ]
-                },
-                "text-transform": "none",
+                "text-max-width": 5,
+                "text-letter-spacing": 0.1,
+                "text-line-height": 1.5,
                 "text-font": [
-                    "Open Sans Regular",
+                    "DIN Offc Pro Italic",
                     "Arial Unicode MS Regular"
                 ],
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.05,
-                "text-max-width": 4
-            },
-            "paint": {
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 2,
-                "text-color": "#2d1617"
-            }
-        },
-        {
-            "id": "oneway_arrows_motorway",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "minzoom": 16,
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "oneway",
-                    1
-                ],
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ]
-            ],
-            "layout": {
-                "text-line-height": 0,
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            8,
-                            8
-                        ],
-                        [
-                            20,
-                            18
-                        ]
-                    ]
-                },
-                "icon-offset": [
-                    0,
-                    2.5
-                ],
-                "icon-image": "oneway_motorway_icon",
-                "text-font": [
-                    "Open Sans Semibold",
-                    "Arial Unicode MS Regular"
-                ],
-                "icon-allow-overlap": true,
-                "symbol-placement": "line",
-                "text-padding": 100,
-                "text-rotation-alignment": "map",
-                "text-anchor": "top",
-                "text-keep-upright": false,
-                "text-field": "",
-                "icon-padding": 0,
-                "icon-ignore-placement": true
-            },
-            "paint": {
-                "text-color": "#504a4c",
-                "text-halo-color": "#aaa",
-                "text-halo-width": 0,
-                "text-translate": [
-                    0,
-                    -2
-                ],
-                "text-opacity": 1
-            }
-        },
-        {
-            "id": "oneway_arrows_small",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "minzoom": 18,
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "oneway",
-                    "true"
-                ],
-                [
-                    "in",
-                    "class",
-                    "street",
-                    "street_limited",
-                    "secondary"
-                ]
-            ],
-            "layout": {
-                "text-line-height": 1,
-                "text-size": 8,
-                "icon-offset": [
-                    0,
-                    2.5
-                ],
-                "icon-image": "oneway_road_icon",
-                "text-font": [
-                    "Open Sans Semibold",
-                    "Arial Unicode MS Regular"
-                ],
-                "icon-allow-overlap": true,
-                "symbol-placement": "line",
-                "text-padding": 100,
-                "text-rotation-alignment": "map",
-                "icon-size": 0.5,
-                "text-keep-upright": false,
-                "text-field": "",
-                "icon-padding": 0,
-                "icon-ignore-placement": true
-            },
-            "paint": {
-                "text-color": "#aaa",
-                "text-halo-color": "#aaa",
-                "text-halo-width": 0,
-                "text-opacity": 1
-            }
-        },
-        {
-            "id": "oneway_arrows_large",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road",
-            "minzoom": 15,
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "oneway",
-                    "true"
-                ],
-                [
-                    "in",
-                    "class",
-                    "trunk",
-                    "primary"
-                ]
-            ],
-            "layout": {
-                "text-line-height": 0,
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            8
-                        ],
-                        [
-                            20,
+                            3,
                             12
-                        ]
-                    ]
-                },
-                "icon-offset": [
-                    0,
-                    0
-                ],
-                "icon-image": "oneway_road",
-                "text-font": [
-                    "Open Sans Semibold",
-                    "Arial Unicode MS Regular"
-                ],
-                "icon-allow-overlap": true,
-                "symbol-placement": "line",
-                "text-padding": 100,
-                "text-rotation-alignment": "map",
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            15,
-                            0.5
                         ],
                         [
-                            22,
-                            1
+                            6,
+                            16
                         ]
                     ]
-                },
-                "text-keep-upright": false,
-                "text-field": "",
-                "text-letter-spacing": 0.5,
-                "icon-padding": 0,
-                "icon-ignore-placement": true
+                }
             },
             "paint": {
-                "text-color": "#aaa",
-                "text-halo-color": "#aaa",
-                "text-halo-width": 0,
-                "text-opacity": 0
+                "text-color": "#78888a",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "road-label-small",
+            "id": "marine-label-md-ln",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858496690.794"
+                "mapbox:group": "1444856087950.3635"
             },
             "source": "composite",
-            "source-layer": "road_label",
+            "source-layer": "marine_label",
+            "minzoom": 2,
+            "maxzoom": 8,
             "interactive": true,
             "filter": [
                 "all",
@@ -5375,1883 +8542,577 @@
                 ],
                 [
                     "in",
-                    "class",
-                    "path",
-                    "service",
-                    "street_limited"
+                    "labelrank",
+                    2,
+                    3
                 ]
             ],
             "layout": {
+                "text-line-height": 1.1,
                 "text-size": {
-                    "base": 1.2,
+                    "base": 1.1,
                     "stops": [
                         [
-                            8,
-                            8
+                            2,
+                            12
                         ],
                         [
-                            20,
-                            18
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "symbol-placement": "line",
-                "text-padding": 0,
-                "text-rotation-alignment": "map",
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.1
-            },
-            "paint": {
-                "text-color": "rgba(140,128,117,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            2
-                        ],
-                        [
-                            20,
-                            3.75
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "road-label-medium",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road_label",
-            "interactive": true,
-            "filter": [
-                "in",
-                "class",
-                "street",
-                "tertiary",
-                "secondary"
-            ],
-            "layout": {
-                "text-size": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            8,
-                            8
-                        ],
-                        [
-                            20,
+                            5,
                             20
                         ]
                     ]
                 },
-                "text-allow-overlap": false,
-                "text-ignore-placement": false,
-                "text-max-angle": 20,
+                "symbol-spacing": 250,
                 "text-font": [
-                    "Open Sans Regular",
+                    "DIN Offc Pro Italic",
                     "Arial Unicode MS Regular"
                 ],
                 "symbol-placement": "line",
-                "text-padding": 0,
-                "text-rotation-alignment": "map",
                 "text-field": "{name_en}",
-                "text-letter-spacing": 0.1
+                "text-letter-spacing": 0.15,
+                "text-max-width": 5
             },
             "paint": {
-                "text-color": "rgba(133,117,60,1)",
-                "text-halo-color": {
-                    "base": 1,
+                "text-color": "#78888a",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "marine-label-md-pt",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444856087950.3635"
+            },
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 2,
+            "maxzoom": 8,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "Point"
+                ],
+                [
+                    "in",
+                    "labelrank",
+                    2,
+                    3
+                ]
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 5,
+                "text-letter-spacing": 0.15,
+                "text-line-height": 1.5,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {
+                    "base": 1.1,
                     "stops": [
                         [
-                            13.9,
-                            "#f8f4f0"
+                            2,
+                            14
                         ],
                         [
-                            14,
-                            "#fff"
-                        ]
-                    ]
-                },
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            2
-                        ],
-                        [
-                            20,
-                            3.75
+                            5,
+                            20
                         ]
                     ]
                 }
+            },
+            "paint": {
+                "text-color": "#78888a",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "road-label-large",
+            "id": "marine-label-lg-ln",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858496690.794"
+                "mapbox:group": "1444856087950.3635"
             },
             "source": "composite",
-            "source-layer": "road_label",
+            "source-layer": "marine_label",
+            "minzoom": 1,
+            "maxzoom": 4,
             "interactive": true,
             "filter": [
-                "in",
-                "class",
-                "primary",
-                "motorway_link",
-                "trunk"
+                "all",
+                [
+                    "==",
+                    "$type",
+                    "LineString"
+                ],
+                [
+                    "==",
+                    "labelrank",
+                    1
+                ]
             ],
             "layout": {
-                "text-size": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            8,
-                            9
-                        ],
-                        [
-                            20,
-                            22
-                        ]
-                    ]
-                },
-                "text-max-angle": 20,
+                "text-field": "{name_en}",
+                "text-max-width": 4,
+                "text-letter-spacing": 0.25,
+                "text-line-height": 1.1,
+                "symbol-placement": "line",
                 "text-font": [
-                    "Open Sans Semibold",
+                    "DIN Offc Pro Italic",
                     "Arial Unicode MS Regular"
                 ],
-                "symbol-placement": "line",
-                "text-padding": 0,
-                "text-rotation-alignment": "map",
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.1
-            },
-            "paint": {
-                "text-color": "rgba(133,117,60,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
+                "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            16,
-                            2
+                            1,
+                            14
                         ],
                         [
-                            20,
-                            3.75
+                            4,
+                            30
                         ]
                     ]
                 }
+            },
+            "paint": {
+                "text-color": "#78888a",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "generic_motorway_label",
+            "id": "marine-label-lg-pt",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858496690.794"
+                "mapbox:group": "1444856087950.3635"
             },
             "source": "composite",
-            "source-layer": "road_label",
+            "source-layer": "marine_label",
+            "minzoom": 1,
+            "maxzoom": 4,
             "interactive": true,
             "filter": [
                 "all",
                 [
-                    "in",
-                    "class",
-                    "motorway",
-                    "motorway_link"
+                    "==",
+                    "$type",
+                    "Point"
                 ],
                 [
                     "==",
-                    "shield",
-                    "default"
-                ],
-                [
-                    "<=",
-                    "reflen",
-                    6
+                    "labelrank",
+                    1
                 ]
             ],
             "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 4,
+                "text-letter-spacing": 0.25,
+                "text-line-height": 1.5,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            10,
-                            10
+                            1,
+                            14
                         ],
                         [
-                            20,
-                            12
+                            4,
+                            30
                         ]
                     ]
-                },
-                "icon-image": "default_{reflen}",
-                "text-transform": "uppercase",
-                "text-font": [
-                    "Open Sans Bold",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 0,
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            1
-                        ],
-                        [
-                            20,
-                            1.25
-                        ]
-                    ]
-                },
-                "text-field": "{ref}",
-                "text-letter-spacing": 0.05
+                }
             },
             "paint": {
-                "text-color": "#fff",
-                "icon-color": "white",
-                "text-halo-color": "#fff",
-                "text-halo-width": 0
+                "text-color": "#78888a",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "us_stateroad_label",
+            "id": "state-label-sm",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858496690.794"
+                "mapbox:group": "1444856151690.9143"
             },
             "source": "composite",
-            "source-layer": "road_label",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 9,
             "interactive": true,
             "filter": [
-                "all",
-                [
-                    "in",
-                    "shield",
-                    "us-state",
-                    "us-state-loop",
-                    "us-state-business",
-                    "us-state-toll",
-                    "us-state-truck"
-                ],
-                [
-                    "==",
-                    "class",
-                    "motorway"
-                ],
-                [
-                    "<=",
-                    "reflen",
-                    3
-                ]
+                "<",
+                "area",
+                20000
             ],
             "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            12
-                        ],
-                        [
-                            20,
-                            15
-                        ]
-                    ]
-                },
-                "icon-image": "us_state_{reflen}",
-                "icon-rotation-alignment": "viewport",
-                "text-font": [
-                    "Open Sans Bold",
-                    "Arial Unicode MS Regular"
-                ],
-                "symbol-placement": "line",
-                "text-padding": 0,
-                "visibility": "visible",
-                "text-rotation-alignment": "viewport",
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.8
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                },
-                "text-field": "{ref}",
-                "icon-padding": 0
-            },
-            "paint": {
-                "text-color": "hsl(7, 4%, 60%)",
-                "icon-color": "white",
-                "text-halo-color": "#fff",
-                "text-halo-width": 0
-            }
-        },
-        {
-            "id": "us_highway_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "shield",
-                    "us-highway",
-                    "us-highway-alternate",
-                    "us-highway-business",
-                    "us-highway-duplex"
-                ],
-                [
-                    "<=",
-                    "reflen",
-                    3
-                ]
-            ],
-            "layout": {
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            12
-                        ],
-                        [
-                            20,
-                            15
-                        ]
-                    ]
-                },
-                "icon-image": "us_highway_{reflen}",
-                "icon-rotation-alignment": "viewport",
-                "text-font": [
-                    "Open Sans Bold",
-                    "Arial Unicode MS Regular"
-                ],
-                "symbol-placement": "line",
-                "visibility": "visible",
-                "text-rotation-alignment": "viewport",
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.85
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                },
-                "text-field": "{ref}",
-                "text-letter-spacing": 0.02
-            },
-            "paint": {
-                "text-color": "hsl(7, 4%, 60%)",
-                "icon-color": "white",
-                "text-halo-color": "#fff",
-                "text-halo-width": 0,
-                "icon-opacity": 1
-            }
-        },
-        {
-            "id": "us_interstate_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858496690.794"
-            },
-            "source": "composite",
-            "source-layer": "road_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "shield",
-                    "us-interstate",
-                    "us-interstate-alternate",
-                    "us-interstate-business",
-                    "us-interstate-duplex"
-                ],
-                [
-                    "<=",
-                    "reflen",
-                    3
-                ]
-            ],
-            "layout": {
-                "text-line-height": 1.4,
                 "text-size": {
                     "base": 1,
                     "stops": [
                         [
                             6,
-                            9
+                            10
                         ],
                         [
-                            20,
+                            9,
+                            14
+                        ]
+                    ]
+                },
+                "text-transform": "uppercase",
+                "text-font": [
+                    "DIN Offc Pro Bold",
+                    "Arial Unicode MS Bold"
+                ],
+                "text-field": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            "{abbr}"
+                        ],
+                        [
+                            6,
+                            "{name_en}"
+                        ]
+                    ]
+                },
+                "text-letter-spacing": 0.15,
+                "text-max-width": 5
+            },
+            "paint": {
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "state-label-md",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444856151690.9143"
+            },
+            "source": "composite",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 8,
+            "interactive": true,
+            "filter": [
+                "all",
+                [
+                    "<",
+                    "area",
+                    80000
+                ],
+                [
+                    ">=",
+                    "area",
+                    20000
+                ]
+            ],
+            "layout": {
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            5,
+                            10
+                        ],
+                        [
+                            8,
                             16
                         ]
                     ]
                 },
-                "icon-offset": [
-                    0,
-                    -2.25
-                ],
-                "icon-image": "interstate_{reflen}",
-                "icon-rotation-alignment": "viewport",
-                "icon-keep-upright": true,
+                "text-transform": "uppercase",
                 "text-font": [
-                    "Open Sans Bold",
-                    "Arial Unicode MS Regular"
+                    "DIN Offc Pro Bold",
+                    "Arial Unicode MS Bold"
                 ],
-                "symbol-placement": "line",
-                "text-offset": [
-                    0,
-                    0.05
-                ],
-                "text-rotation-alignment": "viewport",
-                "icon-size": {
+                "text-field": {
                     "base": 1,
                     "stops": [
                         [
-                            8,
-                            0.75
+                            0,
+                            "{abbr}"
                         ],
                         [
-                            20,
-                            1
+                            5,
+                            "{name_en}"
                         ]
                     ]
                 },
-                "text-field": "{ref}",
-                "text-letter-spacing": 0.02,
-                "icon-padding": 0,
-                "text-max-width": 0
-            },
-            "paint": {
-                "text-color": "white",
-                "text-halo-color": "#fff",
-                "text-halo-width": 0
-            }
-        },
-        {
-            "id": "generic_small_labels",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858346799.9988"
-            },
-            "source": "composite",
-            "source-layer": "poi_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "!in",
-                    "maki",
-                    "rail-light",
-                    "rail-metro",
-                    "rail",
-                    "school",
-                    "park",
-                    "college",
-                    "golf",
-                    "station"
-                ],
-                [
-                    "==",
-                    "scalerank",
-                    4
-                ]
-            ],
-            "layout": {
-                "text-line-height": 1.05,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            20
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "dot",
-                "symbol-avoid-edges": true,
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-justify": "left",
-                "text-padding": 10,
-                "text-offset": [
-                    0,
-                    0
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0.2
-                        ],
-                        [
-                            20,
-                            0.4
-                        ]
-                    ]
-                },
-                "text-anchor": "left",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.05,
+                "text-letter-spacing": 0.15,
                 "text-max-width": 6
             },
             "paint": {
-                "text-color": "hsl(34, 18%, 49%)",
-                "text-halo-color": "#f8f6f0",
-                "text-translate": [
-                    6,
-                    0
-                ],
-                "icon-opacity": 0.6,
-                "text-halo-width": 2
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "small_maki_label",
+            "id": "state-label-lg",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858346799.9988"
+                "mapbox:group": "1444856151690.9143"
             },
             "source": "composite",
-            "source-layer": "poi_label",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 7,
             "interactive": true,
             "filter": [
-                "any",
-                [
-                    "in",
-                    "maki",
-                    "school",
-                    "museum",
-                    "library",
-                    "monument",
-                    "hospital",
-                    "fire-station",
-                    "religious-christian",
-                    "religious-muslim",
-                    "religious-jewish",
-                    "post",
-                    "embassy",
-                    "police",
-                    "prison",
-                    "college",
-                    "harbor",
-                    "airport",
-                    "airfield",
-                    ""
-                ],
-                [
-                    "in",
-                    "type",
-                    "Military",
-                    "Government"
-                ]
+                ">=",
+                "area",
+                80000
             ],
             "layout": {
-                "text-optional": false,
-                "text-line-height": 1,
                 "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "{maki}_icon",
-                "symbol-avoid-edges": true,
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 2,
-                "text-offset": [
-                    0,
-                    1
-                ],
-                "icon-size": {
                     "base": 1,
                     "stops": [
                         [
-                            8,
-                            0.5
-                        ],
-                        [
-                            18,
-                            1
-                        ]
-                    ]
-                },
-                "text-anchor": "top",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.01,
-                "text-max-width": 10
-            },
-            "paint": {
-                "text-color": "rgba(116,100,85,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1.5,
-                    "stops": [
-                        [
-                            11,
-                            2
-                        ],
-                        [
-                            20,
-                            3.75
-                        ]
-                    ]
-                },
-                "icon-opacity": 1
-            }
-        },
-        {
-            "id": "park_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858346799.9988"
-            },
-            "source": "composite",
-            "source-layer": "poi_label",
-            "interactive": true,
-            "filter": [
-                "in",
-                "maki",
-                "park",
-                "golf",
-                "zoo",
-                "cemetery"
-            ],
-            "layout": {
-                "text-optional": false,
-                "text-line-height": 1,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
+                            4,
                             10
                         ],
                         [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "{maki}_icon",
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 6,
-                "visibility": "visible",
-                "text-offset": [
-                    0,
-                    0.9
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0.6
-                        ],
-                        [
-                            18,
-                            1
+                            7,
+                            18
                         ]
                     ]
                 },
-                "text-anchor": "top",
-                "text-field": "{name}",
-                "text-max-width": 8
-            },
-            "paint": {
-                "text-color": "hsl(107, 20%, 34%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 2,
-                "text-halo-blur": 1
-            }
-        },
-        {
-            "id": "airport_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858346799.9988"
-            },
-            "source": "composite",
-            "source-layer": "airport_label",
-            "interactive": true,
-            "layout": {
-                "text-optional": true,
-                "text-line-height": 1,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "airport_icon",
                 "text-transform": "uppercase",
                 "text-font": [
-                    "Open Sans Semibold",
-                    "Arial Unicode MS Regular"
+                    "DIN Offc Pro Bold",
+                    "Arial Unicode MS Bold"
                 ],
-                "text-padding": 5,
-                "text-offset": [
-                    0,
-                    0.9
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0.5
-                        ],
-                        [
-                            18,
-                            1
-                        ]
-                    ]
-                },
-                "text-anchor": "top",
+                "text-padding": 1,
                 "text-field": {
                     "base": 1,
                     "stops": [
                         [
                             0,
-                            "{ref}"
+                            "{abbr}"
                         ],
                         [
-                            11,
-                            "{name}"
-                        ]
-                    ]
-                },
-                "text-letter-spacing": 0.05,
-                "text-max-width": 12
-            },
-            "paint": {
-                "text-color": "#666",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 1
-            }
-        },
-        {
-            "id": "generic_big_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858346799.9988"
-            },
-            "source": "composite",
-            "source-layer": "poi_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "!in",
-                    "maki",
-                    "rail-light",
-                    "rail-metro",
-                    "rail",
-                    "school",
-                    "park",
-                    "cemetery",
-                    "college",
-                    "golf",
-                    "hospital",
-                    "zoo",
-                    "museum",
-                    "post",
-                    "harbor",
-                    "monument",
-                    "airport",
-                    "airfield",
-                    "prison"
-                ],
-                [
-                    "<=",
-                    "scalerank",
-                    2
-                ],
-                [
-                    "!in",
-                    "type",
-                    "Island",
-                    "Wetland",
-                    "Garden",
-                    "Military",
-                    "Government",
-                    "Residential"
-                ]
-            ],
-            "layout": {
-                "text-line-height": 1,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "marker_icon",
-                "text-transform": "none",
-                "text-font": [
-                    "Open Sans Semibold",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 5,
-                "text-offset": [
-                    0,
-                    1
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            0.5
-                        ],
-                        [
-                            18,
-                            1
-                        ]
-                    ]
-                },
-                "text-anchor": "top",
-                "text-field": "{name}",
-                "text-letter-spacing": 0.02,
-                "text-max-width": 10
-            },
-            "paint": {
-                "text-color": "#504a4c",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": 1.5
-            }
-        },
-        {
-            "id": "generic_metro_and_rail_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444858346799.9988"
-            },
-            "source": "composite",
-            "source-layer": "rail_station_label",
-            "interactive": true,
-            "filter": [
-                "in",
-                "maki",
-                "rail-light",
-                "rail-metro",
-                "rail"
-            ],
-            "layout": {
-                "text-line-height": 1,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "{maki}",
-                "text-transform": "none",
-                "text-font": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            [
-                                "Open Sans Regular",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                "Open Sans Semibold",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ]
-                    ]
-                },
-                "text-padding": 0,
-                "visibility": "visible",
-                "text-offset": [
-                    0,
-                    0.9
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                },
-                "text-anchor": "top",
-                "text-field": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            ""
-                        ],
-                        [
-                            15,
+                            4,
                             "{name_en}"
                         ]
                     ]
                 },
-                "text-letter-spacing": 0,
-                "icon-padding": 0,
-                "text-max-width": 5.2,
-                "icon-ignore-placement": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            true
-                        ],
-                        [
-                            13,
-                            false
-                        ]
-                    ]
-                }
+                "text-letter-spacing": 0.15,
+                "text-max-width": 6
             },
             "paint": {
-                "text-color": "rgba(114,94,85,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            2
-                        ],
-                        [
-                            20,
-                            3
-                        ]
-                    ]
-                },
-                "text-opacity": 1
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "networked_rail_label",
+            "id": "country-label-sm",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444858346799.9988"
+                "mapbox:group": "1444856144497.7825"
             },
             "source": "composite",
-            "source-layer": "rail_station_label",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 10,
             "interactive": true,
             "filter": [
-                "all",
-                [
-                    "in",
-                    "maki",
-                    "rail-light",
-                    "rail-metro",
-                    "rail"
-                ],
-                [
-                    "in",
-                    "network",
-                    "paris-rer",
-                    "moscow-metro",
-                    "london-overground",
-                    "london-underground",
-                    "london-dlr",
-                    "gb-national-rail",
-                    "de-s-bahn",
-                    "de-s-bahn.de-u-bahn",
-                    "de-u-bahn",
-                    "paris-transilien",
-                    "london-overground.london-underground",
-                    "gb-national-rail.london-dlr.london-overground.london-underground",
-                    "london-dlr.london-underground",
-                    "gb-national-rail.london-dlr.london-underground",
-                    "paris-metro",
-                    "london-overground.london-underground.national-rail",
-                    "london-overground.national-rail",
-                    "vienna-u-bahn",
-                    "washington-metro",
-                    "london-underground.national-rail",
-                    "san-francisco-bart",
-                    "hong-kong-mtr",
-                    "philadelphia-septa",
-                    "singapore-mrt",
-                    "boston-t",
-                    "barcelona-metro",
-                    "osaka-subway",
-                    "madrid-metro",
-                    "delhi-metro",
-                    "milan-metro",
-                    "mexico-city-metro",
-                    "tokyo-metro",
-                    "new-york-subway",
-                    "chongqing-rail-transit",
-                    "taipei-metro",
-                    "kiev-metro",
-                    "gb-national-rail.london-underground",
-                    "gb-national-rail.london-dlr.london-overground.london-tfl-rail.london-underground",
-                    "london-tfl-rail",
-                    "gb-national-rail.london-overground.london-underground",
-                    "gb-national-rail.london-overground",
-                    "oslo-metro",
-                    "stockholm-metro",
-                    "gb-national-rail.london-tfl-rail.london-overground",
-                    "gb-national-rail.london-tfl-rail.london-underground",
-                    "london-dlr.london-tfl-rail.london-underground",
-                    "london-dlr.london-tfl-rail",
-                    "london-overground.london-tfl-rail.london-underground",
-                    "london-overground.london-tfl-rail",
-                    "london-tfl-rail.london-underground",
-                    "paris-metro.paris-rer"
-                ]
+                ">=",
+                "scalerank",
+                5
             ],
             "layout": {
-                "text-line-height": 1,
-                "text-size": {
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            24
-                        ]
-                    ],
-                    "base": 1.5
-                },
-                "icon-image": "{network}",
-                "symbol-avoid-edges": false,
-                "text-transform": "none",
-                "text-font": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            [
-                                "Open Sans Regular",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ],
-                        [
-                            17,
-                            [
-                                "Open Sans Semibold",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ]
-                    ]
-                },
-                "text-padding": 0,
-                "text-offset": [
-                    0,
-                    1
-                ],
-                "icon-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            0.5
-                        ],
-                        [
-                            20,
-                            1
-                        ]
-                    ]
-                },
-                "text-anchor": "top",
-                "text-field": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            ""
-                        ],
-                        [
-                            15,
-                            "{name_en}"
-                        ]
-                    ]
-                },
-                "text-letter-spacing": 0,
-                "icon-padding": 0,
-                "text-max-width": 5.2,
-                "icon-ignore-placement": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            true
-                        ],
-                        [
-                            13,
-                            false
-                        ]
-                    ]
-                }
-            },
-            "paint": {
-                "text-color": "rgba(114,94,85,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            16,
-                            2
-                        ],
-                        [
-                            20,
-                            3
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "neighborhood_small_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
-            },
-            "source": "composite",
-            "source-layer": "place_label",
-            "maxzoom": 18,
-            "interactive": true,
-            "filter": [
-                "in",
-                "type",
-                "suburb",
-                "island"
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.75
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            12
-                        ],
-                        [
-                            20,
-                            28
-                        ]
-                    ]
-                },
+                "text-field": "{name_en}",
+                "text-max-width": 6,
                 "text-font": [
-                    "Open Sans Italic",
+                    "DIN Offc Pro Medium",
                     "Arial Unicode MS Regular"
                 ],
-                "text-padding": 10,
-                "text-field": "{name_en}",
-                "text-letter-spacing": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.05
-                        ],
-                        [
-                            12,
-                            0.15
-                        ]
-                    ]
-                },
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "rgba(162,99,67,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            1.5
-                        ],
-                        [
-                            20,
-                            5
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "neighborhood_large_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
-            },
-            "source": "composite",
-            "source-layer": "place_label",
-            "maxzoom": 18,
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "type",
-                    "neighbourhood",
-                    "suburb",
-                    "island"
-                ],
-                [
-                    "<=",
-                    "localrank",
-                    5
-                ]
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.75
-                        ]
-                    ]
-                },
                 "text-size": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            12
-                        ],
-                        [
-                            20,
-                            28
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "Open Sans Italic",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 0,
-                "text-field": "{name_en}",
-                "text-letter-spacing": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            10,
-                            0.05
-                        ],
-                        [
-                            12,
-                            0.15
-                        ]
-                    ]
-                },
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "rgba(162,99,67,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            12,
-                            1.5
-                        ],
-                        [
-                            20,
-                            5
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "hamlet_village_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
-            },
-            "source": "composite",
-            "source-layer": "place_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "in",
-                    "type",
-                    "village",
-                    "hamlet"
-                ],
-                [
-                    "<=",
-                    "localrank",
-                    30
-                ]
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.3
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1.05,
-                    "stops": [
-                        [
-                            8,
-                            10
-                        ],
-                        [
-                            20,
-                            28
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 5,
-                "icon-size": 0.9,
-                "text-field": "{name_en}",
-                "text-max-width": 5,
-                "text-letter-spacing": 0.05
-            },
-            "paint": {
-                "text-color": "rgba(117,87,79,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            2
-                        ],
-                        [
-                            20,
-                            3.75
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "town_label",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
-            },
-            "source": "composite",
-            "source-layer": "place_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "type",
-                    "town"
-                ],
-                [
-                    "<=",
-                    "localrank",
-                    40
-                ]
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.3
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1.05,
-                    "stops": [
-                        [
-                            8,
-                            11
-                        ],
-                        [
-                            18,
-                            32
-                        ]
-                    ]
-                },
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "icon-size": 0.9,
-                "text-field": "{name_en}",
-                "text-max-width": 5,
-                "text-letter-spacing": 0.05
-            },
-            "paint": {
-                "text-color": "rgba(115,80,80,1)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.5
-                        ],
-                        [
-                            20,
-                            3.75
-                        ]
-                    ]
-                }
-            }
-        },
-        {
-            "id": "city_label_small",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
-            },
-            "source": "composite",
-            "source-layer": "place_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "!in",
-                    "scalerank",
-                    1,
-                    2,
-                    3,
-                    4,
-                    0
-                ]
-            ],
-            "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.3
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1.05,
+                    "base": 0.9,
                     "stops": [
                         [
                             5,
-                            11
+                            14
                         ],
                         [
-                            18,
-                            36
-                        ]
-                    ]
-                },
-                "symbol-avoid-edges": true,
-                "text-font": [
-                    "Open Sans Regular",
-                    "Arial Unicode MS Regular"
-                ],
-                "text-padding": 0,
-                "icon-size": 0.8,
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.02,
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "hsl(357, 14%, 37%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            6,
-                            1.5
-                        ],
-                        [
-                            20,
-                            6
+                            9,
+                            22
                         ]
                     ]
                 }
-            }
-        },
-        {
-            "id": "city_label_medium",
-            "type": "symbol",
-            "metadata": {
-                "mapbox:group": "1444857916000.3777"
             },
-            "source": "composite",
-            "source-layer": "place_label",
-            "interactive": true,
-            "filter": [
-                "all",
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "in",
-                    "scalerank",
-                    3,
-                    4
-                ]
-            ],
-            "layout": {
-                "text-line-height": {
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
                     "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.3
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1.05,
                     "stops": [
                         [
                             2,
-                            8
+                            "rgba(255,255,255,0.75)"
                         ],
                         [
-                            18,
-                            40
+                            3,
+                            "#fff"
                         ]
                     ]
                 },
-                "icon-image": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "dot"
-                        ],
-                        [
-                            6,
-                            ""
-                        ]
-                    ]
-                },
-                "text-font": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            [
-                                "Open Sans Regular",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ],
-                        [
-                            6,
-                            [
-                                "Open Sans Semibold",
-                                "Arial Unicode MS Regular"
-                            ]
-                        ]
-                    ]
-                },
-                "text-padding": 0,
-                "text-offset": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5.99,
-                            [
-                                0,
-                                0.25
-                            ]
-                        ],
-                        [
-                            6,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
-                },
-                "icon-size": 0.35,
-                "text-anchor": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "top"
-                        ],
-                        [
-                            6,
-                            "center"
-                        ]
-                    ]
-                },
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.02,
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "hsl(357, 14%, 37%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            1.75
-                        ],
-                        [
-                            18,
-                            2.75
-                        ]
-                    ]
-                }
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
             }
         },
         {
-            "id": "city_label_big",
+            "id": "country-label-md",
             "type": "symbol",
             "metadata": {
-                "mapbox:group": "1444857916000.3777"
+                "mapbox:group": "1444856144497.7825"
             },
             "source": "composite",
-            "source-layer": "place_label",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 8,
             "interactive": true,
             "filter": [
-                "all",
-                [
-                    "==",
-                    "type",
-                    "city"
-                ],
-                [
-                    "<=",
-                    "scalerank",
-                    2
-                ]
+                "in",
+                "scalerank",
+                3,
+                4
             ],
             "layout": {
-                "text-line-height": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            8,
-                            1.1
-                        ],
-                        [
-                            20,
-                            1.3
-                        ]
-                    ]
-                },
-                "text-size": {
-                    "base": 1.05,
-                    "stops": [
-                        [
-                            1.9,
-                            10
-                        ],
-                        [
-                            18,
-                            40
-                        ]
-                    ]
-                },
-                "icon-image": {
+                "text-field": {
                     "base": 1,
                     "stops": [
                         [
                             0,
-                            "dot"
+                            "{code}"
                         ],
                         [
-                            6,
-                            ""
+                            2,
+                            "{name_en}"
+                        ]
+                    ]
+                },
+                "text-max-width": 6,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            3,
+                            10
+                        ],
+                        [
+                            8,
+                            24
+                        ]
+                    ]
+                }
+            },
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            2,
+                            "rgba(255,255,255,0.75)"
+                        ],
+                        [
+                            3,
+                            "#fff"
+                        ]
+                    ]
+                },
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "country-label-lg",
+            "type": "symbol",
+            "metadata": {
+                "mapbox:group": "1444856144497.7825"
+            },
+            "source": "composite",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 7,
+            "interactive": true,
+            "filter": [
+                "in",
+                "scalerank",
+                1,
+                2
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            5
+                        ],
+                        [
+                            3,
+                            6
                         ]
                     ]
                 },
                 "text-font": [
-                    "Open Sans Semibold",
+                    "DIN Offc Pro Medium",
                     "Arial Unicode MS Regular"
                 ],
-                "text-padding": 0,
-                "text-offset": {
+                "text-size": {
                     "base": 1,
                     "stops": [
                         [
-                            5.99,
-                            [
-                                0,
-                                0.25
-                            ]
+                            1,
+                            10
                         ],
                         [
                             6,
-                            [
-                                0,
-                                0
-                            ]
-                        ]
-                    ]
-                },
-                "icon-size": 0.4,
-                "text-anchor": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            0,
-                            "top"
-                        ],
-                        [
-                            6,
-                            "center"
-                        ]
-                    ]
-                },
-                "text-field": "{name_en}",
-                "text-letter-spacing": 0.02,
-                "icon-padding": 0,
-                "text-max-width": 5
-            },
-            "paint": {
-                "text-color": "hsl(357, 14%, 37%)",
-                "text-halo-color": "#f8f6f0",
-                "text-halo-width": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            6,
-                            1.75
-                        ],
-                        [
-                            18,
-                            2.75
+                            24
                         ]
                     ]
                 }
+            },
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            2,
+                            "rgba(255,255,255,0.75)"
+                        ],
+                        [
+                            3,
+                            "#fff"
+                        ]
+                    ]
+                },
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
             }
         },
         {
@@ -7261,12 +9122,20 @@
                 "mapbox:group": "1458461767759.1262"
             },
             "source": "composite",
-            "source-layer": "US_Congressional_Districts_114th_2015_Labels",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "==",
-                "fill",
-                "#fed9a6"
+                "all",
+                [
+                    "==",
+                    "fill",
+                    "#fed9a6"
+                ],
+                [
+                    "==",
+                    "group",
+                    "label"
+                ]
             ],
             "layout": {
                 "text-field": {
@@ -7325,12 +9194,20 @@
                 "mapbox:group": "1458461767759.1262"
             },
             "source": "composite",
-            "source-layer": "US_Congressional_Districts_114th_2015_Labels",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "==",
-                "fill",
-                "#fbb4ae"
+                "all",
+                [
+                    "==",
+                    "fill",
+                    "#fbb4ae"
+                ],
+                [
+                    "==",
+                    "group",
+                    "label"
+                ]
             ],
             "layout": {
                 "text-field": {
@@ -7389,12 +9266,20 @@
                 "mapbox:group": "1458461767759.1262"
             },
             "source": "composite",
-            "source-layer": "US_Congressional_Districts_114th_2015_Labels",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "==",
-                "fill",
-                "#decbe4"
+                "all",
+                [
+                    "==",
+                    "fill",
+                    "#decbe4"
+                ],
+                [
+                    "==",
+                    "group",
+                    "label"
+                ]
             ],
             "layout": {
                 "text-field": {
@@ -7453,12 +9338,20 @@
                 "mapbox:group": "1458461767759.1262"
             },
             "source": "composite",
-            "source-layer": "US_Congressional_Districts_114th_2015_Labels",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "==",
-                "fill",
-                "#ccebc5"
+                "all",
+                [
+                    "==",
+                    "fill",
+                    "#ccebc5"
+                ],
+                [
+                    "==",
+                    "group",
+                    "label"
+                ]
             ],
             "layout": {
                 "text-field": {
@@ -7517,12 +9410,20 @@
                 "mapbox:group": "1458461767759.1262"
             },
             "source": "composite",
-            "source-layer": "US_Congressional_Districts_114th_2015_Labels",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "==",
-                "fill",
-                "#b3cde3"
+                "all",
+                [
+                    "==",
+                    "fill",
+                    "#b3cde3"
+                ],
+                [
+                    "==",
+                    "group",
+                    "label"
+                ]
             ],
             "layout": {
                 "text-field": {
@@ -7575,9 +9476,9 @@
             }
         }
     ],
-    "created": "2016-04-28T03:09:43.502Z",
-    "id": "cinjppgm9002paem5x0w9ajeb",
-    "modified": "2016-04-28T03:09:43.502Z",
+    "created": "2016-05-16T01:22:43.205Z",
+    "id": "cio9bt6oc002aadnmatvm5tpe",
+    "modified": "2016-05-16T01:22:43.205Z",
     "owner": "USER",
     "draft": false
 }

--- a/mapbox-style-template.json
+++ b/mapbox-style-template.json
@@ -23,7 +23,7 @@
             },
             "1444934295202.7542": {
                 "name": "Admin boundaries",
-                "collapsed": true
+                "collapsed": false
             },
             "1444856151690.9143": {
                 "name": "State labels",
@@ -40,6 +40,9 @@
             "1444933808272.805": {
                 "name": "Water labels",
                 "collapsed": true
+            },
+            "1463427334849.3604": {
+                "name": "Districts"
             },
             "1444933372896.5967": {
                 "name": "POI labels (scalerank 3)",
@@ -61,27 +64,38 @@
                 "name": "City labels",
                 "collapsed": true
             },
+            "1463427634286.75": {
+                "name": "District Boundaries"
+            },
             "1444855769305.6016": {
                 "name": "Tunnels",
                 "collapsed": true
             },
             "1456970288113.8113": {
                 "name": "Landcover",
-                "collapsed": true
+                "collapsed": false
             },
             "1444856144497.7825": {
                 "name": "Country labels",
                 "collapsed": true
             }
-        }
+        },
+        "mapbox:trackposition": false
     },
+    "center": [
+        -99.77018878497046,
+        38.30490800231652
+    ],
+    "zoom": 3.1138900684543085,
+    "bearing": 0,
+    "pitch": 0,
     "sources": {
         "composite": {
-            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,USER.cd-114-2015",
+            "url": "mapbox://mapbox.mapbox-streets-v7,USER.cd-114-2015",
             "type": "vector"
         }
     },
-    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "glyphs": "mapbox://fonts/USER/{fontstack}/{range}.pbf",
     "layers": [
         {
             "id": "background",
@@ -90,233 +104,6 @@
             "layout": {},
             "paint": {
                 "background-color": "hsl(55, 11%, 96%)"
-            }
-        },
-        {
-            "id": "landcover_wood",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "maxzoom": 14,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "wood"
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 89%)",
-                "fill-opacity": 0.1,
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "landcover_scrub",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "maxzoom": 14,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "scrub"
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 89%)",
-                "fill-opacity": 0.1,
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "landcover_grass",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "maxzoom": 14,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "grass"
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 89%)",
-                "fill-opacity": 0.1,
-                "fill-antialias": false
-            }
-        },
-	 {
-            "id": "districts_5",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1458418542199.6687"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#fed9a6"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "#fed9a6",
-                "fill-opacity": 0.45
-            }
-        },
-        {
-            "id": "districts_4",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1458418542199.6687"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#fbb4ae"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "#fbb4ae",
-                "fill-opacity": 0.45
-            }
-        },
-        {
-            "id": "districts_3",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1458418542199.6687"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#decbe4"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "#decbe4",
-                "fill-opacity": 0.45
-            }
-        },
-        {
-            "id": "districts_2",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1458418542199.6687"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#ccebc5"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "#ccebc5",
-                "fill-opacity": 0.45
-            }
-        },
-        {
-            "id": "districts_1",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1458418542199.6687"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#b3cde3"
-            ],
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "fill-color": "#b3cde3",
-                "fill-opacity": 0.45
-            }
-        },
-        {
-            "id": "landcover_crop",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456970288113.8113"
-            },
-            "source": "composite",
-            "source-layer": "landcover",
-            "maxzoom": 14,
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "crop"
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 89%)",
-                "fill-opacity": 0.1,
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "national_park",
-            "type": "fill",
-            "source": "composite",
-            "source-layer": "landuse_overlay",
-            "interactive": true,
-            "filter": [
-                "==",
-                "class",
-                "national_park"
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(150, 6%, 93%)",
-                "fill-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            5,
-                            0
-                        ],
-                        [
-                            6,
-                            0.5
-                        ]
-                    ]
-                }
             }
         },
         {
@@ -394,204 +181,6 @@
             "layout": {},
             "paint": {
                 "fill-color": "hsl(150, 6%, 93%)"
-            }
-        },
-        {
-            "id": "hillshade_highlight_bright",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                94
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "#fff",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.08
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "hillshade_highlight_med",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                90
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "#fff",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.08
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "hillshade_shadow_faint",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                89
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 35%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.033
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "hillshade_shadow_med",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                78
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 35%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.033
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "hillshade_shadow_dark",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                67
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 35%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.06
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
-            }
-        },
-        {
-            "id": "hillshade_shadow_extreme",
-            "type": "fill",
-            "metadata": {
-                "mapbox:group": "1456969573402.7817"
-            },
-            "source": "composite",
-            "source-layer": "hillshade",
-            "maxzoom": 16,
-            "interactive": true,
-            "filter": [
-                "==",
-                "level",
-                56
-            ],
-            "layout": {},
-            "paint": {
-                "fill-color": "hsl(0, 0%, 35%)",
-                "fill-opacity": {
-                    "stops": [
-                        [
-                            14,
-                            0.06
-                        ],
-                        [
-                            16,
-                            0
-                        ]
-                    ]
-                },
-                "fill-antialias": false
             }
         },
         {
@@ -5723,36 +5312,6 @@
             }
         },
         {
-            "id": "districts_boundary_line",
-            "type": "line",
-            "source": "composite",
-            "source-layer": "districts",
-            "minzoom": 4,
-            "interactive": true,
-            "layout": {
-                "line-join": "miter"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "hsl(0, 0%, 11%)",
-                "line-offset": 0,
-                "line-opacity": 1,
-                "line-blur": 5
-            }
-        },
-        {
             "id": "bridge-rail",
             "type": "line",
             "metadata": {
@@ -6267,83 +5826,435 @@
             }
         },
         {
-            "id": "admin-3-4-boundaries-bg",
-            "type": "line",
+            "id": "districts_5",
+            "type": "fill",
             "metadata": {
-                "mapbox:group": "1444934295202.7542"
+                "mapbox:group": "1463427334849.3604"
             },
             "source": "composite",
-            "source-layer": "admin",
+            "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "all",
-                [
-                    ">=",
-                    "admin_level",
-                    3
-                ],
-                [
-                    "==",
-                    "maritime",
-                    0
-                ]
+                "==",
+                "fill",
+                "#fed9a6"
             ],
             "layout": {
-                "line-join": "bevel"
+                "visibility": "visible"
             },
             "paint": {
-                "line-color": "hsl(0, 0%, 84%)",
-                "line-width": {
+                "fill-color": "#fed9a6",
+                "fill-opacity": {
                     "base": 1,
                     "stops": [
                         [
-                            3,
-                            3.5
+                            0,
+                            0.7
                         ],
                         [
                             10,
-                            8
-                        ]
-                    ]
-                },
-                "line-opacity": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            4,
-                            0
-                        ],
-                        [
-                            7,
-                            0.5
-                        ],
-                        [
-                            8,
-                            0.75
-                        ]
-                    ]
-                },
-                "line-dasharray": [
-                    1,
-                    0
-                ],
-                "line-translate": [
-                    0,
-                    0
-                ],
-                "line-blur": {
-                    "base": 1,
-                    "stops": [
-                        [
-                            3,
-                            0
-                        ],
-                        [
-                            8,
-                            3
+                            0.1
                         ]
                     ]
                 }
+            }
+        },
+        {
+            "id": "districts_4",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1463427334849.3604"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#fbb4ae"
+            ],
+            "layout": {
+                "visibility": "visible"
+            },
+            "paint": {
+                "fill-color": "#fbb4ae",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            0.7
+                        ],
+                        [
+                            10,
+                            0.1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "districts_3",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1463427334849.3604"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#decbe4"
+            ],
+            "layout": {
+                "visibility": "visible"
+            },
+            "paint": {
+                "fill-color": "#decbe4",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            0.7
+                        ],
+                        [
+                            10,
+                            0.1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "districts_2",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1463427334849.3604"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#ccebc5"
+            ],
+            "layout": {
+                "visibility": "visible"
+            },
+            "paint": {
+                "fill-color": "#ccebc5",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            0.7
+                        ],
+                        [
+                            10,
+                            0.1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "districts_1",
+            "type": "fill",
+            "metadata": {
+                "mapbox:group": "1463427334849.3604"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#b3cde3"
+            ],
+            "layout": {
+                "visibility": "visible"
+            },
+            "paint": {
+                "fill-color": "#b3cde3",
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            0,
+                            0.7
+                        ],
+                        [
+                            10,
+                            0.1
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "districts_5_boundary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1463427634286.75"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#fed9a6"
+            ],
+            "layout": {},
+            "paint": {
+                "line-width": {
+                    "base": 1.1,
+                    "stops": [
+                        [
+                            0.5,
+                            0
+                        ],
+                        [
+                            22,
+                            24
+                        ]
+                    ]
+                },
+                "line-offset": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fed9a6",
+                "line-opacity": 0.9
+            }
+        },
+        {
+            "id": "districts_4_boundary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1463427634286.75"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#fbb4ae"
+            ],
+            "layout": {},
+            "paint": {
+                "line-width": {
+                    "base": 1.1,
+                    "stops": [
+                        [
+                            0.5,
+                            0
+                        ],
+                        [
+                            22,
+                            24
+                        ]
+                    ]
+                },
+                "line-offset": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#fbb4ae",
+                "line-opacity": 0.9
+            }
+        },
+        {
+            "id": "districts_3_boundary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1463427634286.75"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#decbe4"
+            ],
+            "layout": {},
+            "paint": {
+                "line-width": {
+                    "base": 1.1,
+                    "stops": [
+                        [
+                            0.5,
+                            0
+                        ],
+                        [
+                            22,
+                            24
+                        ]
+                    ]
+                },
+                "line-offset": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#decbe4",
+                "line-opacity": 0.9
+            }
+        },
+        {
+            "id": "districts_2_boundary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1463427634286.75"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#ccebc5"
+            ],
+            "layout": {},
+            "paint": {
+                "line-width": {
+                    "base": 1.1,
+                    "stops": [
+                        [
+                            0.5,
+                            0
+                        ],
+                        [
+                            22,
+                            24
+                        ]
+                    ]
+                },
+                "line-offset": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#ccebc5",
+                "line-opacity": 0.9
+            }
+        },
+        {
+            "id": "districts_1_boundary",
+            "type": "line",
+            "metadata": {
+                "mapbox:group": "1463427634286.75"
+            },
+            "source": "composite",
+            "source-layer": "districts",
+            "interactive": true,
+            "filter": [
+                "==",
+                "fill",
+                "#b3cde3"
+            ],
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.1,
+                    "stops": [
+                        [
+                            0.5,
+                            0
+                        ],
+                        [
+                            22,
+                            24
+                        ]
+                    ]
+                },
+                "line-offset": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "#b3cde3",
+                "line-opacity": 0.9
+            }
+        },
+        {
+            "id": "districts_boundary_line",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "districts",
+            "minzoom": 4,
+            "interactive": true,
+            "layout": {
+                "line-join": "miter"
+            },
+            "paint": {
+                "line-width": {
+                    "base": 1.2,
+                    "stops": [
+                        [
+                            1,
+                            1
+                        ],
+                        [
+                            22,
+                            12
+                        ]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 11%)",
+                "line-offset": 0,
+                "line-opacity": 1,
+                "line-blur": 5
             }
         },
         {
@@ -6443,7 +6354,8 @@
             ],
             "layout": {
                 "line-join": "round",
-                "line-cap": "round"
+                "line-cap": "round",
+                "visibility": "visible"
             },
             "paint": {
                 "line-dasharray": {
@@ -6471,12 +6383,12 @@
                     "base": 1,
                     "stops": [
                         [
-                            7,
-                            0.75
+                            3,
+                            2
                         ],
                         [
                             12,
-                            1.5
+                            4
                         ]
                     ]
                 },
@@ -6502,7 +6414,7 @@
                         ],
                         [
                             5,
-                            "hsl(0, 0%, 70%)"
+                            "hsl(0, 2%, 57%)"
                         ]
                     ]
                 }
@@ -6559,11 +6471,11 @@
                     "stops": [
                         [
                             3,
-                            0.5
+                            1
                         ],
                         [
                             10,
-                            2
+                            4
                         ]
                     ]
                 }
@@ -6631,238 +6543,6 @@
                         ]
                     ]
                 }
-            }
-        },
-	 {
-            "id": "districts_5_boundary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1458486127563.5833"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#fed9a6"
-            ],
-            "layout": {},
-            "paint": {
-                "line-width": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0.5,
-                            0
-                        ],
-                        [
-                            22,
-                            24
-                        ]
-                    ]
-                },
-                "line-offset": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "#fed9a6",
-                "line-opacity": 0.9
-            }
-        },
-        {
-            "id": "districts_4_boundary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1458486127563.5833"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#fbb4ae"
-            ],
-            "layout": {},
-            "paint": {
-                "line-width": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0.5,
-                            0
-                        ],
-                        [
-                            22,
-                            24
-                        ]
-                    ]
-                },
-                "line-offset": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "#fbb4ae",
-                "line-opacity": 0.9
-            }
-        },
-        {
-            "id": "districts_3_boundary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1458486127563.5833"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#decbe4"
-            ],
-            "layout": {},
-            "paint": {
-                "line-width": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0.5,
-                            0
-                        ],
-                        [
-                            22,
-                            24
-                        ]
-                    ]
-                },
-                "line-offset": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "#decbe4",
-                "line-opacity": 0.9
-            }
-        },
-        {
-            "id": "districts_2_boundary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1458486127563.5833"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#ccebc5"
-            ],
-            "layout": {},
-            "paint": {
-                "line-width": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0.5,
-                            0
-                        ],
-                        [
-                            22,
-                            24
-                        ]
-                    ]
-                },
-                "line-offset": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "#ccebc5",
-                "line-opacity": 0.9
-            }
-        },
-        {
-            "id": "districts_1_boundary",
-            "type": "line",
-            "metadata": {
-                "mapbox:group": "1458486127563.5833"
-            },
-            "source": "composite",
-            "source-layer": "districts",
-            "interactive": true,
-            "filter": [
-                "==",
-                "fill",
-                "#b3cde3"
-            ],
-            "layout": {
-                "line-join": "miter"
-            },
-            "paint": {
-                "line-width": {
-                    "base": 1.1,
-                    "stops": [
-                        [
-                            0.5,
-                            0
-                        ],
-                        [
-                            22,
-                            24
-                        ]
-                    ]
-                },
-                "line-offset": {
-                    "base": 1.2,
-                    "stops": [
-                        [
-                            1,
-                            1
-                        ],
-                        [
-                            22,
-                            12
-                        ]
-                    ]
-                },
-                "line-color": "#b3cde3",
-                "line-opacity": 0.9
             }
         },
         {
@@ -7631,9 +7311,9 @@
             },
             "paint": {
                 "text-color": "#6B6B6B",
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1,
-                "text-halo-blur": 0
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-blur": 0,
+                "text-halo-width": 1
             }
         },
         {
@@ -7675,9 +7355,9 @@
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
-                "text-halo-width": 1,
+                "text-halo-blur": 0,
                 "text-color": "hsl(0, 0%, 62%)",
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -7719,9 +7399,9 @@
             },
             "paint": {
                 "text-halo-color": "hsl(0, 0%, 100%)",
-                "text-halo-width": 1,
+                "text-halo-blur": 0,
                 "text-color": "hsl(0, 0%, 62%)",
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -7758,10 +7438,10 @@
                 }
             },
             "paint": {
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1.25,
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-blur": 0,
                 "text-color": "hsl(0, 0%, 62%)",
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -7803,8 +7483,8 @@
                 ]
             },
             "paint": {
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1.25,
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-blur": 0,
                 "text-color": {
                     "base": 1,
                     "stops": [
@@ -7818,7 +7498,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -7889,8 +7569,8 @@
                         ]
                     ]
                 },
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1.25,
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-blur": 0,
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -7904,7 +7584,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -7951,9 +7631,9 @@
             },
             "paint": {
                 "text-color": "#6B6B6B",
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1,
-                "text-halo-blur": 0
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-blur": 0,
+                "text-halo-width": 1
             }
         },
         {
@@ -8026,8 +7706,7 @@
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 42%)",
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1.25,
+                "text-halo-color": "hsl(0, 0%, 100%)",
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -8041,7 +7720,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -8114,10 +7793,6 @@
                 }
             },
             "paint": {
-                "text-halo-width": 1,
-                "text-halo-color": "#ffffff",
-                "text-color": "hsl(0, 0%, 42%)",
-                "text-halo-blur": 0,
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -8130,7 +7805,10 @@
                             0
                         ]
                     ]
-                }
+                },
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-width": 1
             }
         },
         {
@@ -8205,8 +7883,7 @@
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 42%)",
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1,
+                "text-halo-color": "hsl(0, 0%, 100%)",
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -8220,7 +7897,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -8295,8 +7972,7 @@
             },
             "paint": {
                 "text-color": "hsl(0, 0%, 42%)",
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1,
+                "text-halo-color": "hsl(0, 0%, 100%)",
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -8310,7 +7986,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -8386,8 +8062,7 @@
             "paint": {
                 "text-color": "hsl(0, 0%, 42%)",
                 "text-opacity": 1,
-                "text-halo-color": "#ffffff",
-                "text-halo-width": 1,
+                "text-halo-color": "hsl(0, 0%, 100%)",
                 "icon-opacity": {
                     "base": 1,
                     "stops": [
@@ -8401,7 +8076,7 @@
                         ]
                     ]
                 },
-                "text-halo-blur": 0
+                "text-halo-width": 1
             }
         },
         {
@@ -9413,17 +9088,9 @@
             "source-layer": "districts",
             "interactive": true,
             "filter": [
-                "all",
-                [
-                    "==",
-                    "fill",
-                    "#b3cde3"
-                ],
-                [
-                    "==",
-                    "group",
-                    "label"
-                ]
+                "==",
+                "fill",
+                "#b3cde3"
             ],
             "layout": {
                 "text-field": {
@@ -9476,9 +9143,9 @@
             }
         }
     ],
-    "created": "2016-05-16T01:22:43.205Z",
-    "id": "cio9bt6oc002aadnmatvm5tpe",
-    "modified": "2016-05-16T01:22:43.205Z",
+    "created": "2016-05-16T19:57:15.074Z",
+    "id": "cioafmhk70047adnmt3gz2kd0",
+    "modified": "2016-05-16T19:57:57.935Z",
     "owner": "USER",
     "draft": false
 }

--- a/process.js
+++ b/process.js
@@ -72,13 +72,13 @@ colored.features.map(function(d) {
   d.properties.state = state;
 
   // add metadata to the label
-  pt.properties = d.properties;
+  pt.properties = JSON.parse(JSON.stringify(d.properties)); // copy hack to avoid mutability issues
   pt.properties.title_short = state + ' ' + (number == "00" ? "At Large" : parseInt(number));
   pt.properties.title_long = state_name + '’s ' + (number == "00" ? "At Large" : ordinal(parseInt(number))) + ' Congressional District';
 
   // add a type property to distinguish between labels and boundaries
-  pt.group = 'label';
-  d.group = 'boundary';
+  pt.properties.group = 'label';
+  d.properties.group = 'boundary';
 
   // add both the label point and congressional district to the mapData feature collection
   mapData.features.push(pt);

--- a/process.js
+++ b/process.js
@@ -76,6 +76,10 @@ colored.features.map(function(d) {
   pt.properties.title_short = state + ' ' + (number == "00" ? "At Large" : parseInt(number));
   pt.properties.title_long = state_name + '’s ' + (number == "00" ? "At Large" : ordinal(parseInt(number))) + ' Congressional District';
 
+  // add a type property to distinguish between labels and boundaries
+  pt.group = 'label';
+  d.group = 'boundary';
+
   // add both the label point and congressional district to the mapData feature collection
   mapData.features.push(pt);
   mapData.features.push(d);

--- a/process.js
+++ b/process.js
@@ -93,13 +93,6 @@ colored.features.map(function(d) {
   }
 });
 
-// Use the Tippecanoe GeoJSON extension to specify that each label and district feature should be
-// included at all levels from min to max zoom. https://github.com/mapbox/tippecanoe#geojson-extension
-mapData.features.map(function(d) {
-  d.tippecanoe = { "maxzoom" : 12, "minzoom" : 0 };
-  return d;
-});
-
 // get the bounding boxes of all of the bounding boxes for each state
 for (var s in stateBboxes) {
   stateBboxes[s] = turf.extent(stateBboxes[s]);

--- a/process.js
+++ b/process.js
@@ -39,7 +39,7 @@ var districtBboxes = {},
     stateBboxes = {};
 
 // empty FeatureCollection to contain final map data
-var mapData = { 'type': 'FeatureCollection', 'features', [] }
+var mapData = { 'type': 'FeatureCollection', 'features': [] }
 
 colored.features.map(function(d) {
 
@@ -106,7 +106,7 @@ for (var s in stateBboxes) {
 }
 
 // write out data for the next steps
-console.log('data ready');
+console.log('writing data...');
 
 fs.writeFileSync('./data/map.geojson', JSON.stringify(mapData));
 
@@ -116,3 +116,5 @@ var bboxes = {};
 for (var b in districtBboxes) { bboxes[b] = districtBboxes[b] };
 for (var b in stateBboxes) { bboxes[b] = stateBboxes[b] };
 fs.writeFileSync('./example/bboxes.js', 'var bboxes = ' + JSON.stringify(bboxes, null, 2));
+
+console.log('finished processing, ready for tiling');

--- a/upload.js
+++ b/upload.js
@@ -3,12 +3,11 @@ var fs = require('fs'),
     AWS = require('aws-sdk');
 
 var districtsFile = process.argv[2],
-    labelsFile = process.argv[3],
     user = process.env.MAPBOX_USERNAME,
     accessToken = process.env.MAPBOX_WRITE_SCOPE_ACCESS_TOKEN;
 
 var tileset_id = user + ".cd-114-2015"; // max 32 characters (including "-labels" added below), only one period
-var tielset_name = "US_Congressional_Districts_114th_2015"; // max 64 characters (including "_Labels" added below) no spaces
+var tileset_name = "US_Congressional_Districts_114th_2015"; // max 64 characters (including "_Labels" added below) no spaces
 
 var client = new MapboxClient(accessToken);
 
@@ -48,5 +47,4 @@ function upload_tileset(file, id, name) {
 
 // do the upload
 
-upload_tileset(labelsFile, tileset_id + '-labels', tielset_name + '_Labels')
-upload_tileset(districtsFile, tileset_id, tielset_name)
+upload_tileset(districtsFile, tileset_id, tileset_name)


### PR DESCRIPTION
- district labels and boundaries now in same data file
- uploads a single vector tile source
- no longer uses Mapbox Terrain
- reducing number of tilesets used from 4 to 2
- updates to cartography, using latest Mapbox Light style as a basemap
